### PR TITLE
feat: allow to override provider url upon installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         
       - name: Run anvil
-        run: anvil
+        run: anvil &
 
       - name: Run local examples with Foundry
         run: scripts/examples evm_rpc_local 'Number = 0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,14 @@ jobs:
         run: scripts/e2e
 
       - name: Run examples
-        run: scripts/examples evm_rpc_local 'Number = 20000000'
+        run: scripts/examples evm_rpc 'Number = 20000000'
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
         
+      - name: Run anvil
+        run: anvil
+
       - name: Run local examples with Foundry
         run: scripts/examples evm_rpc_local 'Number = 0'
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: arduino/setup-protoc@v3
 
       - name: Cargo test
-        run: unset CI && cargo test
+        run: unset CI && cargo test -- --show-output --nocapture
 
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: arduino/setup-protoc@v3
 
       - name: Cargo test
-        run: unset CI && cargo test -- --show-output --nocapture
+        run: unset CI && cargo test -- --test-threads=1
 
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,10 @@ jobs:
         run: scripts/e2e
 
       - name: Run examples
-        run: scripts/examples
+        run: scripts/examples evm_rpc_local 'Number = 20000000'
+        
+      - name: Run local examples with Foundry
+        run: scripts/examples evm_rpc_local 'Number = 0'
       
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -116,10 +116,14 @@ type LogFilter = variant {
   ShowPattern : Regex;
   HidePattern : Regex;
 };
+type RegexSubstitution = record {
+  pattern : Regex;
+  replacement: text;
+};
 // Override resolved provider.
 // Useful for testing with a local Ethereum developer environment such as foundry.
 type OverrideProvider = record {
-  overrideUrl : opt Regex
+  overrideUrl : opt RegexSubstitution
 };
 type JsonRpcError = record { code : int64; message : text };
 type LogEntry = record {

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -107,6 +107,7 @@ type InstallArgs = record {
   demo : opt bool;
   manageApiKeys : opt vec principal;
   logFilter : opt LogFilter;
+  overrideProvider : opt OverrideProvider;
 };
 type Regex = text;
 type LogFilter = variant {
@@ -114,6 +115,11 @@ type LogFilter = variant {
   HideAll;
   ShowPattern : Regex;
   HidePattern : Regex;
+};
+// Override resolved provider.
+// Useful for testing with a local Ethereum developer environment such as foundry.
+type OverrideProvider = record {
+  overrideUrl : opt Regex
 };
 type JsonRpcError = record { code : int64; message : text };
 type LogEntry = record {

--- a/dfx.json
+++ b/dfx.json
@@ -24,6 +24,13 @@
       "gzip": true,
       "init_arg": "(record {demo = opt true})"
     },
+    "evm_rpc_local": {
+      "candid": "candid/evm_rpc.did",
+      "type": "rust",
+      "package": "evm_rpc",
+      "gzip": true,
+      "init_arg": "( record {  overrideProvider = opt record { overrideUrl = opt record { pattern = \".*\"; replacement = \"http://127.0.0.1:8545\" } } })"
+    },
     "evm_rpc_staging": {
       "candid": "candid/evm_rpc.did",
       "type": "rust",

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 
-pub use lifecycle::{InstallArgs, LogFilter, OverrideProvider, RegexString};
+pub use lifecycle::{InstallArgs, LogFilter, OverrideProvider, RegexString, RegexSubstitution};
 pub use request::{
     AccessList, AccessListEntry, BlockTag, CallArgs, FeeHistoryArgs, GetLogsArgs,
     GetTransactionCountArgs, TransactionRequest,

--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 
-pub use lifecycle::{InstallArgs, LogFilter, RegexString};
+pub use lifecycle::{InstallArgs, LogFilter, OverrideProvider, RegexString};
 pub use request::{
     AccessList, AccessListEntry, BlockTag, CallArgs, FeeHistoryArgs, GetLogsArgs,
     GetTransactionCountArgs, TransactionRequest,

--- a/evm_rpc_types/src/lifecycle/mod.rs
+++ b/evm_rpc_types/src/lifecycle/mod.rs
@@ -9,7 +9,7 @@ pub struct InstallArgs {
     #[serde(rename = "logFilter")]
     pub log_filter: Option<LogFilter>,
     #[serde(rename = "overrideProvider")]
-    pub override_provider: Option<OverrideProvider>
+    pub override_provider: Option<OverrideProvider>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
@@ -23,7 +23,7 @@ pub enum LogFilter {
 #[derive(Clone, Debug, Default, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct OverrideProvider {
     #[serde(rename = "overrideUrl")]
-    pub override_url: Option<RegexString>
+    pub override_url: Option<RegexString>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]

--- a/evm_rpc_types/src/lifecycle/mod.rs
+++ b/evm_rpc_types/src/lifecycle/mod.rs
@@ -23,8 +23,14 @@ pub enum LogFilter {
 #[derive(Clone, Debug, Default, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct OverrideProvider {
     #[serde(rename = "overrideUrl")]
-    pub override_url: Option<RegexString>,
+    pub override_url: Option<RegexSubstitution>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct RegexString(pub String);
+
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub struct RegexSubstitution {
+    pub pattern: RegexString,
+    pub replacement: String,
+}

--- a/evm_rpc_types/src/lifecycle/mod.rs
+++ b/evm_rpc_types/src/lifecycle/mod.rs
@@ -8,6 +8,8 @@ pub struct InstallArgs {
     pub manage_api_keys: Option<Vec<Principal>>,
     #[serde(rename = "logFilter")]
     pub log_filter: Option<LogFilter>,
+    #[serde(rename = "overrideProvider")]
+    pub override_provider: Option<OverrideProvider>
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
@@ -16,6 +18,12 @@ pub enum LogFilter {
     HideAll,
     ShowPattern(RegexString),
     HidePattern(RegexString),
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub struct OverrideProvider {
+    #[serde(rename = "overrideUrl")]
+    pub override_url: Option<RegexString>
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -4,6 +4,7 @@
     dfx canister create --all &&
     npm run generate &&
     dfx deploy evm_rpc --mode reinstall -y &&
+    dfx deploy evm_rpc_local --mode reinstall -y &&
     dfx deploy evm_rpc_demo --mode reinstall -y &&
     dfx deploy evm_rpc_staging --mode reinstall -y &&
     dfx deploy e2e_rust &&

--- a/scripts/examples
+++ b/scripts/examples
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 # Run a variety of example RPC calls.
 
+CANISTER_ID=${1:-evm_rpc}
+# Use concrete block height to avoid flakiness on CI
+BLOCK_HEIGHT=${2:-'Number = 20000000'}
+
 NETWORK=local
 IDENTITY=default
-CANISTER_ID=evm_rpc
 CYCLES=10000000000
 WALLET=$(dfx identity get-wallet --network=$NETWORK --identity=$IDENTITY)
 RPC_SERVICE="EthMainnet=variant {PublicNode}"
 RPC_SERVICES=EthMainnet
 RPC_CONFIG="opt record {responseConsensus = opt variant {Threshold = record {total = opt (3 : nat8); min = 2 : nat8}}}"
-# Use concrete block height to avoid flakiness on CI
-BLOCK_HEIGHT="Number = 20000000"
 
 FLAGS="--network=$NETWORK --identity=$IDENTITY --with-cycles=$CYCLES --wallet=$WALLET"
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,9 +1,8 @@
-use crate::memory::get_override_provider;
 use crate::{
     accounting::{get_cost_with_collateral, get_http_request_cost},
     add_metric_entry,
     constants::{CONTENT_TYPE_HEADER_LOWERCASE, CONTENT_TYPE_VALUE},
-    memory::is_demo_active,
+    memory::{get_override_provider, is_demo_active},
     types::{MetricRpcHost, MetricRpcMethod, ResolvedRpcService},
     util::canonicalize_json,
 };

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,3 +1,4 @@
+use crate::memory::get_override_provider;
 use crate::{
     accounting::{get_cost_with_collateral, get_http_request_cost},
     add_metric_entry,
@@ -20,7 +21,7 @@ pub async fn json_rpc_request(
     max_response_bytes: u64,
 ) -> RpcResult<HttpResponse> {
     let cycles_cost = get_http_request_cost(json_rpc_payload.len() as u64, max_response_bytes);
-    let api = service.api();
+    let api = service.api(&get_override_provider())?;
     let mut request_headers = api.headers.unwrap_or_default();
     if !request_headers
         .iter()

--- a/src/http.rs
+++ b/src/http.rs
@@ -42,20 +42,19 @@ pub async fn json_rpc_request(
             vec![],
         )),
     };
-    http_request(rpc_method, service, request, cycles_cost).await
+    http_request(rpc_method, request, cycles_cost).await
 }
 
 pub async fn http_request(
     rpc_method: MetricRpcMethod,
-    service: ResolvedRpcService,
     request: CanisterHttpRequestArgument,
     cycles_cost: u128,
 ) -> RpcResult<HttpResponse> {
-    let api = service.api();
-    let parsed_url = match url::Url::parse(&api.url) {
+    let url = request.url.clone();
+    let parsed_url = match url::Url::parse(&url) {
         Ok(url) => url,
         Err(_) => {
-            return Err(ValidationError::Custom(format!("Error parsing URL: {}", api.url)).into())
+            return Err(ValidationError::Custom(format!("Error parsing URL: {}", url)).into())
         }
     };
     let host = match parsed_url.host_str() {
@@ -63,7 +62,7 @@ pub async fn http_request(
         None => {
             return Err(ValidationError::Custom(format!(
                 "Error parsing hostname from URL: {}",
-                api.url
+                url
             ))
             .into())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,10 @@ use evm_rpc::candid_rpc::CandidRpcClient;
 use evm_rpc::constants::NODES_IN_SUBNET;
 use evm_rpc::http::get_http_response_body;
 use evm_rpc::logs::INFO;
-use evm_rpc::memory::{insert_api_key, is_api_key_principal, is_demo_active, remove_api_key, set_api_key_principals, set_demo_active, set_log_filter, set_override_provider};
+use evm_rpc::memory::{
+    insert_api_key, is_api_key_principal, is_demo_active, remove_api_key, set_api_key_principals,
+    set_demo_active, set_log_filter, set_override_provider,
+};
 use evm_rpc::metrics::encode_metrics;
 use evm_rpc::providers::{find_provider, resolve_rpc_service, PROVIDERS, SERVICE_PROVIDER_MAP};
 use evm_rpc::types::{LogFilter, OverrideProvider, Provider, ProviderId, RpcAccess, RpcAuth};
@@ -268,7 +271,7 @@ fn post_upgrade(args: evm_rpc_types::InstallArgs) {
     if let Some(filter) = args.log_filter {
         set_log_filter(LogFilter::from(filter))
     }
-    if let Some(override_provider)  =args.override_provider {
+    if let Some(override_provider) = args.override_provider {
         set_override_provider(OverrideProvider::from(override_provider));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,10 +269,13 @@ fn post_upgrade(args: evm_rpc_types::InstallArgs) {
         set_api_key_principals(principals);
     }
     if let Some(filter) = args.log_filter {
-        set_log_filter(LogFilter::from(filter))
+        set_log_filter(LogFilter::try_from(filter).expect("ERROR: Invalid log filter"));
     }
     if let Some(override_provider) = args.override_provider {
-        set_override_provider(OverrideProvider::from(override_provider));
+        set_override_provider(
+            OverrideProvider::try_from(override_provider)
+                .expect("ERROR: invalid override provider"),
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,10 @@ use evm_rpc::candid_rpc::CandidRpcClient;
 use evm_rpc::constants::NODES_IN_SUBNET;
 use evm_rpc::http::get_http_response_body;
 use evm_rpc::logs::INFO;
-use evm_rpc::memory::{
-    insert_api_key, is_api_key_principal, is_demo_active, remove_api_key, set_api_key_principals,
-    set_demo_active, set_log_filter,
-};
+use evm_rpc::memory::{insert_api_key, is_api_key_principal, is_demo_active, remove_api_key, set_api_key_principals, set_demo_active, set_log_filter, set_override_provider};
 use evm_rpc::metrics::encode_metrics;
 use evm_rpc::providers::{find_provider, resolve_rpc_service, PROVIDERS, SERVICE_PROVIDER_MAP};
-use evm_rpc::types::{LogFilter, Provider, ProviderId, RpcAccess, RpcAuth};
+use evm_rpc::types::{LogFilter, OverrideProvider, Provider, ProviderId, RpcAccess, RpcAuth};
 use evm_rpc::{
     http::{json_rpc_request, transform_http_request},
     http_types,
@@ -270,6 +267,9 @@ fn post_upgrade(args: evm_rpc_types::InstallArgs) {
     }
     if let Some(filter) = args.log_filter {
         set_log_filter(LogFilter::from(filter))
+    }
+    if let Some(override_provider)  =args.override_provider {
+        set_override_provider(OverrideProvider::from(override_provider));
     }
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -7,12 +7,13 @@ use ic_stable_structures::{
 use ic_stable_structures::{Cell, StableBTreeMap};
 use std::cell::RefCell;
 
-use crate::types::{ApiKey, LogFilter, Metrics, ProviderId};
+use crate::types::{ApiKey, LogFilter, Metrics, OverrideProvider, ProviderId};
 
 const IS_DEMO_ACTIVE_MEMORY_ID: MemoryId = MemoryId::new(4);
 const API_KEY_MAP_MEMORY_ID: MemoryId = MemoryId::new(5);
 const MANAGE_API_KEYS_MEMORY_ID: MemoryId = MemoryId::new(6);
 const LOG_FILTER_MEMORY_ID: MemoryId = MemoryId::new(7);
+const OVERRIDE_PROVIDER_MEMORY_ID: MemoryId = MemoryId::new(8);
 
 type StableMemory = VirtualMemory<DefaultMemoryImpl>;
 
@@ -31,7 +32,9 @@ thread_local! {
     static MANAGE_API_KEYS: RefCell<ic_stable_structures::Vec<Principal, StableMemory>> =
         RefCell::new(ic_stable_structures::Vec::init(MEMORY_MANAGER.with_borrow(|m| m.get(MANAGE_API_KEYS_MEMORY_ID))).expect("Unable to read API key principals from stable memory"));
     static LOG_FILTER: RefCell<Cell<LogFilter, StableMemory>> =
-        RefCell::new(ic_stable_structures::Cell::init(MEMORY_MANAGER.with_borrow(|m| m.get(LOG_FILTER_MEMORY_ID)), LogFilter::default()).expect("Unable to read log message filter from stable memory"));
+        RefCell::new(Cell::init(MEMORY_MANAGER.with_borrow(|m| m.get(LOG_FILTER_MEMORY_ID)), LogFilter::default()).expect("Unable to read log message filter from stable memory"));
+    static OVERRIDE_PROVIDER: RefCell<Cell<OverrideProvider, StableMemory>> =
+        RefCell::new(Cell::init(MEMORY_MANAGER.with_borrow(|m| m.get(OVERRIDE_PROVIDER_MEMORY_ID)), OverrideProvider::default()).expect("Unable to read provider override from stable memory"));
 }
 
 pub fn get_api_key(provider_id: ProviderId) -> Option<ApiKey> {
@@ -83,6 +86,18 @@ pub fn set_log_filter(filter: LogFilter) {
         state
             .set(filter)
             .expect("Error while updating log message filter")
+    });
+}
+
+pub fn get_override_provider() -> OverrideProvider {
+    OVERRIDE_PROVIDER.with_borrow(|provider| provider.get().clone())
+}
+
+pub fn set_override_provider(provider: OverrideProvider) {
+    OVERRIDE_PROVIDER.with_borrow_mut(|state| {
+        state
+            .set(provider)
+            .expect("Error while updating override provider")
     });
 }
 

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::accounting::get_http_request_cost;
 use crate::logs::{DEBUG, TRACE_HTTP};
-use crate::memory::next_request_id;
+use crate::memory::{get_override_provider, next_request_id};
 use crate::providers::resolve_rpc_service;
 use crate::rpc_client::eth_rpc_error::{sanitize_send_raw_transaction_result, Parser};
 use crate::rpc_client::json::requests::JsonRpcRequest;
@@ -11,9 +11,9 @@ use crate::rpc_client::json::responses::{
     Block, FeeHistory, JsonRpcReply, JsonRpcResult, LogEntry, TransactionReceipt,
 };
 use crate::rpc_client::numeric::{TransactionCount, Wei};
-use crate::types::MetricRpcMethod;
+use crate::types::{MetricRpcMethod, OverrideProvider};
 use candid::candid_method;
-use evm_rpc_types::{HttpOutcallError, ProviderError, RpcApi, RpcError, RpcService};
+use evm_rpc_types::{HttpOutcallError, RpcApi, RpcError, RpcService};
 use ic_canister_log::log;
 use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::management_canister::http_request::{
@@ -181,7 +181,7 @@ where
         method: eth_method.clone(),
         id: 1,
     };
-    let api = resolve_api(provider)?;
+    let api = resolve_api(provider, &get_override_provider())?;
     let url = &api.url;
     let mut headers = vec![HttpHeader {
         name: "Content-Type".to_string(),
@@ -271,8 +271,11 @@ where
     }
 }
 
-fn resolve_api(service: &RpcService) -> Result<RpcApi, ProviderError> {
-    Ok(resolve_rpc_service(service.clone())?.api())
+fn resolve_api(
+    service: &RpcService,
+    override_provider: &OverrideProvider,
+) -> Result<RpcApi, RpcError> {
+    resolve_rpc_service(service.clone())?.api(override_provider)
 }
 
 async fn http_request(

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -221,9 +221,7 @@ where
             )),
         };
 
-        let response = match http_request(provider, &eth_method, request, effective_size_estimate)
-            .await
-        {
+        let response = match http_request(&eth_method, request, effective_size_estimate).await {
             Err(RpcError::HttpOutcallError(HttpOutcallError::IcError { code, message }))
                 if is_response_too_large(&code, &message) =>
             {
@@ -278,12 +276,10 @@ fn resolve_api(service: &RpcService) -> Result<RpcApi, ProviderError> {
 }
 
 async fn http_request(
-    service: &RpcService,
     method: &str,
     request: CanisterHttpRequestArgument,
     effective_response_size_estimate: u64,
 ) -> Result<HttpResponse, RpcError> {
-    let service = resolve_rpc_service(service.clone())?;
     let cycles_cost = get_http_request_cost(
         request
             .body
@@ -293,7 +289,7 @@ async fn http_request(
         effective_response_size_estimate,
     );
     let rpc_method = MetricRpcMethod(method.to_string());
-    crate::http::http_request(rpc_method, service, request, cycles_cost).await
+    crate::http::http_request(rpc_method, request, cycles_cost).await
 }
 
 fn http_status_code(response: &HttpResponse) -> u16 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,7 @@ use crate::memory::get_api_key;
 use crate::util::hostname_from_url;
 use crate::validate::validate_api_key;
 use candid::CandidType;
+use evm_rpc_types::RpcApi;
 use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::management_canister::http_request::HttpHeader;
 use ic_stable_structures::storable::Bound;

--- a/src/types.rs
+++ b/src/types.rs
@@ -347,6 +347,12 @@ impl RegexString {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegexSubstitution {
+    pub pattern: RegexString,
+    pub replacement: String,
+}
+
 impl LogFilter {
     pub fn is_match(&self, message: &str) -> bool {
         match self {
@@ -380,7 +386,7 @@ impl Storable for LogFilter {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct OverrideProvider {
-    pub override_url: Option<RegexString>,
+    pub override_url: Option<RegexSubstitution>,
 }
 
 impl From<evm_rpc_types::OverrideProvider> for OverrideProvider {
@@ -388,7 +394,10 @@ impl From<evm_rpc_types::OverrideProvider> for OverrideProvider {
         evm_rpc_types::OverrideProvider { override_url }: evm_rpc_types::OverrideProvider,
     ) -> Self {
         Self {
-            override_url: override_url.map(RegexString::from),
+            override_url: override_url.map(|substitution| RegexSubstitution {
+                pattern: RegexString::from(substitution.pattern),
+                replacement: substitution.replacement,
+            }),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use crate::constants::{API_KEY_MAX_SIZE, API_KEY_REPLACE_STRING, MESSAGE_FILTER_MAX_SIZE};
 use crate::memory::get_api_key;
 use crate::util::hostname_from_url;
@@ -374,6 +377,25 @@ impl Storable for LogFilter {
     };
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct OverrideProvider {
+    pub override_url: Option<RegexString>,
+}
+
+impl Storable for OverrideProvider {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        serde_json::to_vec(self)
+            .expect("Error while serializing `OverrideProvider`")
+            .into()
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        serde_json::from_slice(&bytes).expect("Error while deserializing `Storable`")
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RpcAuth {
     /// API key will be used in an Authorization header as Bearer token, e.g.,
@@ -384,46 +406,4 @@ pub enum RpcAuth {
     UrlParameter {
         url_pattern: &'static str,
     },
-}
-
-#[cfg(test)]
-mod test {
-    use super::{LogFilter, RegexString};
-    use ic_stable_structures::Storable;
-
-    #[test]
-    fn test_message_filter_storable() {
-        let patterns: &[RegexString] =
-            &["[.]", "^DEBUG ", "(.*)?", "\\?"].map(|regex| regex.into());
-        let cases = [
-            vec![
-                (LogFilter::ShowAll, r#""ShowAll""#.to_string()),
-                (LogFilter::HideAll, r#""HideAll""#.to_string()),
-            ],
-            patterns
-                .iter()
-                .map(|regex| {
-                    (
-                        LogFilter::ShowPattern(regex.clone()),
-                        format!(r#"{{"ShowPattern":{:?}}}"#, regex.0),
-                    )
-                })
-                .collect(),
-            patterns
-                .iter()
-                .map(|regex| {
-                    (
-                        LogFilter::HidePattern(regex.clone()),
-                        format!(r#"{{"HidePattern":{:?}}}"#, regex.0),
-                    )
-                })
-                .collect(),
-        ]
-        .concat();
-        for (filter, expected_json) in cases {
-            let bytes = filter.to_bytes();
-            assert_eq!(String::from_utf8(bytes.to_vec()).unwrap(), expected_json);
-            assert_eq!(filter, LogFilter::from_bytes(bytes));
-        }
-    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -382,6 +382,16 @@ pub struct OverrideProvider {
     pub override_url: Option<RegexString>,
 }
 
+impl From<evm_rpc_types::OverrideProvider> for OverrideProvider {
+    fn from(
+        evm_rpc_types::OverrideProvider { override_url }: evm_rpc_types::OverrideProvider,
+    ) -> Self {
+        Self {
+            override_url: override_url.map(RegexString::from),
+        }
+    }
+}
+
 impl Storable for OverrideProvider {
     fn to_bytes(&self) -> Cow<[u8]> {
         serde_json::to_vec(self)

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -1,4 +1,4 @@
-use super::{LogFilter, OverrideProvider, RegexString};
+use super::{LogFilter, OverrideProvider, RegexString, RegexSubstitution};
 use ic_stable_structures::Storable;
 use proptest::prelude::{Just, Strategy};
 use proptest::{option, prop_oneof, proptest};
@@ -20,6 +20,13 @@ fn arb_regex() -> impl Strategy<Value = RegexString> {
     ".*".prop_map(|r| RegexString::from(r.as_str()))
 }
 
+fn arb_regex_substitution() -> impl Strategy<Value = RegexSubstitution> {
+    (arb_regex(), ".*").prop_map(|(pattern, replacement)| RegexSubstitution {
+        pattern,
+        replacement,
+    })
+}
+
 fn arb_log_filter() -> impl Strategy<Value = LogFilter> {
     prop_oneof![
         Just(LogFilter::ShowAll),
@@ -30,7 +37,7 @@ fn arb_log_filter() -> impl Strategy<Value = LogFilter> {
 }
 
 fn arb_override_provider() -> impl Strategy<Value = OverrideProvider> {
-    option::of(arb_regex()).prop_map(|override_url| OverrideProvider { override_url })
+    option::of(arb_regex_substitution()).prop_map(|override_url| OverrideProvider { override_url })
 }
 
 fn test_encoding_decoding_roundtrip<T: Storable + PartialEq + Debug>(value: &T) {

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -1,0 +1,40 @@
+use super::{LogFilter, OverrideProvider, RegexString};
+use ic_stable_structures::Storable;
+use proptest::prelude::{Just, Strategy};
+use proptest::{option, prop_oneof, proptest};
+use std::fmt::Debug;
+
+proptest! {
+    #[test]
+    fn should_encode_decode_log_filter(value in arb_log_filter()) {
+        test_encoding_decoding_roundtrip(&value);
+    }
+
+    #[test]
+    fn should_encode_decode_override_provider(value in arb_override_provider()) {
+        test_encoding_decoding_roundtrip(&value);
+    }
+}
+
+fn arb_regex() -> impl Strategy<Value = RegexString> {
+    ".*".prop_map(|r| RegexString::from(r.as_str()))
+}
+
+fn arb_log_filter() -> impl Strategy<Value = LogFilter> {
+    prop_oneof![
+        Just(LogFilter::ShowAll),
+        Just(LogFilter::HideAll),
+        arb_regex().prop_map(LogFilter::ShowPattern),
+        arb_regex().prop_map(LogFilter::HidePattern),
+    ]
+}
+
+fn arb_override_provider() -> impl Strategy<Value = OverrideProvider> {
+    option::of(arb_regex()).prop_map(|override_url| OverrideProvider { override_url })
+}
+
+fn test_encoding_decoding_roundtrip<T: Storable + PartialEq + Debug>(value: &T) {
+    let bytes = value.to_bytes();
+    let decoded_value = T::from_bytes(bytes);
+    assert_eq!(value, &decoded_value);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -91,9 +91,8 @@ impl Default for EvmRpcSetup {
 impl EvmRpcSetup {
     pub fn new() -> Self {
         Self::with_args(InstallArgs {
-            manage_api_keys: None,
             demo: Some(true),
-            log_filter: None,
+            ..Default::default()
         })
     }
 


### PR DESCRIPTION
Allow to override the URL that will be queried by the EVM RPC canister via a regex specified upon canister installation. This is allows testing against a local Ethereum development setup (such as [foundry](https://github.com/foundry-rs/foundry)) without changing the client calling the EVM RPC canister.