### PR TITLE
fix: make subnet nodes configurable and fix https outcall cost calculation

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -108,6 +108,7 @@ type InstallArgs = record {
   manageApiKeys : opt vec principal;
   logFilter : opt LogFilter;
   overrideProvider : opt OverrideProvider;
+  nodesInSubnet : opt nat32;
 };
 type Regex = text;
 type LogFilter = variant {

--- a/e2e/motoko/main.mo
+++ b/e2e/motoko/main.mo
@@ -14,7 +14,7 @@ shared ({ caller = installer }) actor class Main() {
 
     // (`subnet name`, `nodes in subnet`, `expected cycles for JSON-RPC call`)
     type SubnetTarget = (Text, Nat32, Nat);
-    let fiduciarySubnet : SubnetTarget = ("fiduciary", 34, 544_244_800);
+    let fiduciarySubnet : SubnetTarget = ("fiduciary", 34, 540_532_000);
 
     let testTargets = [
         // (`canister module`, `canister type`, `subnet`)

--- a/e2e/motoko/main.mo
+++ b/e2e/motoko/main.mo
@@ -14,7 +14,7 @@ shared ({ caller = installer }) actor class Main() {
 
     // (`subnet name`, `nodes in subnet`, `expected cycles for JSON-RPC call`)
     type SubnetTarget = (Text, Nat32, Nat);
-    let fiduciarySubnet : SubnetTarget = ("fiduciary", 34, 642_627_200);
+    let fiduciarySubnet : SubnetTarget = ("fiduciary", 34, 544_244_800);
 
     let testTargets = [
         // (`canister module`, `canister type`, `subnet`)

--- a/evm_rpc_types/src/lifecycle/mod.rs
+++ b/evm_rpc_types/src/lifecycle/mod.rs
@@ -10,6 +10,8 @@ pub struct InstallArgs {
     pub log_filter: Option<LogFilter>,
     #[serde(rename = "overrideProvider")]
     pub override_provider: Option<OverrideProvider>,
+    #[serde(rename = "nodesInSubnet")]
+    pub nodes_in_subnet: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -1,56 +1,63 @@
-use crate::constants::{
-    CANISTER_OVERHEAD, COLLATERAL_CYCLES_PER_NODE, HTTP_OUTCALL_REQUEST_BASE_COST,
-    HTTP_OUTCALL_REQUEST_COST_PER_BYTE, HTTP_OUTCALL_REQUEST_PER_NODE_COST,
-    HTTP_OUTCALL_RESPONSE_COST_PER_BYTE, INGRESS_MESSAGE_BYTE_RECEIVED_COST,
-    INGRESS_MESSAGE_RECEIVED_COST, INGRESS_OVERHEAD_BYTES, NODES_IN_SUBNET, RPC_URL_COST_BYTES,
-};
+use crate::constants::{COLLATERAL_CYCLES_PER_NODE, INGRESS_OVERHEAD_BYTES, RPC_URL_COST_BYTES};
 
 /// Calculates the cost of sending a JSON-RPC request using HTTP outcalls.
-pub fn get_http_request_cost(payload_size_bytes: u64, max_response_bytes: u64) -> u128 {
-    let nodes_in_subnet = NODES_IN_SUBNET as u128;
+/// See https://internetcomputer.org/docs/current/developer-docs/gas-cost/#https-outcalls
+pub fn get_http_request_cost(
+    nodes_in_subnet: u32,
+    payload_size_bytes: u64,
+    max_response_bytes: u64,
+) -> u128 {
+    let n = nodes_in_subnet as u128;
     let ingress_bytes =
         payload_size_bytes as u128 + RPC_URL_COST_BYTES as u128 + INGRESS_OVERHEAD_BYTES;
-    let cost_per_node = INGRESS_MESSAGE_RECEIVED_COST
-        + INGRESS_MESSAGE_BYTE_RECEIVED_COST * ingress_bytes
-        + HTTP_OUTCALL_REQUEST_BASE_COST
-        + HTTP_OUTCALL_REQUEST_PER_NODE_COST * nodes_in_subnet
-        + HTTP_OUTCALL_REQUEST_COST_PER_BYTE * payload_size_bytes as u128
-        + HTTP_OUTCALL_RESPONSE_COST_PER_BYTE * max_response_bytes as u128
-        + CANISTER_OVERHEAD;
-    cost_per_node * nodes_in_subnet
+    let response_bytes = max_response_bytes as u128;
+    let base_fee = (3_000_000 + 60_000 * n) * n;
+    let request_fee = 400 * n * ingress_bytes;
+    let response_fee = 800 * n * response_bytes;
+    base_fee + request_fee + response_fee
 }
 
 /// Calculate the cost + collateral cycles for an HTTP request.
-pub fn get_cost_with_collateral(cycles_cost: u128) -> u128 {
-    cycles_cost + COLLATERAL_CYCLES_PER_NODE * NODES_IN_SUBNET as u128
+pub fn get_cost_with_collateral(nodes_in_subnet: u32, cycles_cost: u128) -> u128 {
+    cycles_cost + COLLATERAL_CYCLES_PER_NODE * nodes_in_subnet as u128
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{accounting::get_http_request_cost, constants::NODES_IN_SUBNET};
 
     #[test]
     fn test_request_cost() {
+        let nodes_in_subnet = 34;
         let payload = "{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}";
-        let base_cost = get_http_request_cost(payload.len() as u64, 1000);
-        let base_cost_10_extra_bytes = get_http_request_cost(payload.len() as u64 + 10, 1000);
-        let estimated_cost_10_extra_bytes = base_cost
-            + 10 * (INGRESS_MESSAGE_BYTE_RECEIVED_COST + HTTP_OUTCALL_REQUEST_COST_PER_BYTE)
-                * NODES_IN_SUBNET as u128;
+        let base_cost = get_http_request_cost(nodes_in_subnet, payload.len() as u64, 1000);
+        let base_cost_10_extra_bytes =
+            get_http_request_cost(nodes_in_subnet, payload.len() as u64 + 10, 1000);
+        let estimated_cost_10_extra_bytes = base_cost + 400 * nodes_in_subnet as u128 * 10;
         assert_eq!(base_cost_10_extra_bytes, estimated_cost_10_extra_bytes);
     }
 
     #[test]
     fn test_candid_rpc_cost() {
+        let nodes = 13;
         assert_eq!(
             [
-                get_http_request_cost(0, 0),
-                get_http_request_cost(123, 123),
-                get_http_request_cost(123, 4567890),
-                get_http_request_cost(890, 4567890),
+                get_http_request_cost(nodes, 0, 0),
+                get_http_request_cost(nodes, 123, 123),
+                get_http_request_cost(nodes, 123, 4567890),
+                get_http_request_cost(nodes, 890, 4567890),
             ],
-            [270368000, 283750400, 124527012800, 124589600000]
+            [50991200, 52910000, 47557686800, 47561675200]
+        );
+        let nodes = 34;
+        assert_eq!(
+            [
+                get_http_request_cost(nodes, 0, 0),
+                get_http_request_cost(nodes, 123, 123),
+                get_http_request_cost(nodes, 123, 4567890),
+                get_http_request_cost(nodes, 890, 4567890),
+            ],
+            [176201600, 181220000, 124424482400, 124434913600]
         );
     }
 }

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -1,15 +1,15 @@
-use crate::constants::{COLLATERAL_CYCLES_PER_NODE, INGRESS_OVERHEAD_BYTES, RPC_URL_COST_BYTES};
+use crate::constants::COLLATERAL_CYCLES_PER_NODE;
 
 /// Calculates the cost of sending a JSON-RPC request using HTTP outcalls.
 /// See https://internetcomputer.org/docs/current/developer-docs/gas-cost/#https-outcalls
 pub fn get_http_request_cost(
     nodes_in_subnet: u32,
-    payload_size_bytes: u64,
+    payload_body_bytes: u64,
+    extra_payload_bytes: u64,
     max_response_bytes: u64,
 ) -> u128 {
     let n = nodes_in_subnet as u128;
-    let request_bytes =
-        payload_size_bytes as u128 + RPC_URL_COST_BYTES as u128 + INGRESS_OVERHEAD_BYTES;
+    let request_bytes = (payload_body_bytes + extra_payload_bytes) as u128;
     base_fee(n) + request_fee(n, request_bytes) + response_fee(n, max_response_bytes as u128)
 }
 
@@ -34,13 +34,20 @@ pub fn get_cost_with_collateral(nodes_in_subnet: u32, cycles_cost: u128) -> u128
 mod test {
     use super::*;
 
+    const OVERHEAD_BYTES: u64 = 356;
+
     #[test]
     fn test_request_cost() {
         let nodes_in_subnet = 34;
         let payload = "{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}";
-        let base_cost = get_http_request_cost(nodes_in_subnet, payload.len() as u64, 1000);
-        let base_cost_10_extra_bytes =
-            get_http_request_cost(nodes_in_subnet, payload.len() as u64 + 10, 1000);
+        let base_cost =
+            get_http_request_cost(nodes_in_subnet, payload.len() as u64, OVERHEAD_BYTES, 1000);
+        let base_cost_10_extra_bytes = get_http_request_cost(
+            nodes_in_subnet,
+            payload.len() as u64 + 10,
+            OVERHEAD_BYTES,
+            1000,
+        );
         let estimated_cost_10_extra_bytes = base_cost + 400 * nodes_in_subnet as u128 * 10;
         assert_eq!(base_cost_10_extra_bytes, estimated_cost_10_extra_bytes);
     }
@@ -63,20 +70,20 @@ mod test {
         let nodes = 13;
         assert_eq!(
             [
-                get_http_request_cost(nodes, 0, 0),
-                get_http_request_cost(nodes, 123, 123),
-                get_http_request_cost(nodes, 123, 4567890),
-                get_http_request_cost(nodes, 890, 4567890),
+                get_http_request_cost(nodes, 0, OVERHEAD_BYTES, 0),
+                get_http_request_cost(nodes, 123, OVERHEAD_BYTES, 123),
+                get_http_request_cost(nodes, 123, OVERHEAD_BYTES, 4567890),
+                get_http_request_cost(nodes, 890, OVERHEAD_BYTES, 4567890),
             ],
             [50991200, 52910000, 47557686800, 47561675200]
         );
         let nodes = 34;
         assert_eq!(
             [
-                get_http_request_cost(nodes, 0, 0),
-                get_http_request_cost(nodes, 123, 123),
-                get_http_request_cost(nodes, 123, 4567890),
-                get_http_request_cost(nodes, 890, 4567890),
+                get_http_request_cost(nodes, 0, OVERHEAD_BYTES, 0),
+                get_http_request_cost(nodes, 123, OVERHEAD_BYTES, 123),
+                get_http_request_cost(nodes, 123, OVERHEAD_BYTES, 4567890),
+                get_http_request_cost(nodes, 890, OVERHEAD_BYTES, 4567890),
             ],
             [176201600, 181220000, 124424482400, 124434913600]
         );

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,10 @@
 // Constant used in HTTP outcall cost calculation
 pub const INGRESS_OVERHEAD_BYTES: u128 = 100;
 
+// The default value of max_resposne_bytes is 2MiB, according to
+// https://docs.rs/ic-cdk/latest/ic_cdk/api/management_canister/http_request/struct.CanisterHttpRequestArgument.html
+pub const DEFAULT_MAX_RESPONSE_BYTES: u64 = 2 * (1 << 20);
+
 // Cycles which must be passed with each RPC request in case the
 // third-party JSON-RPC prices increase in the future (currently always refunded)
 pub const COLLATERAL_CYCLES_PER_NODE: u128 = 10_000_000;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,3 @@
-// Constant used in HTTP outcall cost calculation
-pub const INGRESS_OVERHEAD_BYTES: u128 = 100;
-
 // The default value of max_resposne_bytes is 2MiB, according to
 // https://docs.rs/ic-cdk/latest/ic_cdk/api/management_canister/http_request/struct.CanisterHttpRequestArgument.html
 pub const DEFAULT_MAX_RESPONSE_BYTES: u64 = 2 * (1 << 20);
@@ -8,9 +5,6 @@ pub const DEFAULT_MAX_RESPONSE_BYTES: u64 = 2 * (1 << 20);
 // Cycles which must be passed with each RPC request in case the
 // third-party JSON-RPC prices increase in the future (currently always refunded)
 pub const COLLATERAL_CYCLES_PER_NODE: u128 = 10_000_000;
-
-// Minimum number of bytes charged for a URL; improves consistency of costs between providers
-pub const RPC_URL_COST_BYTES: u32 = 256;
 
 pub const MINIMUM_WITHDRAWAL_CYCLES: u128 = 1_000_000_000;
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,5 @@
-// The default value of max_resposne_bytes is 2MiB, according to
-// https://docs.rs/ic-cdk/latest/ic_cdk/api/management_canister/http_request/struct.CanisterHttpRequestArgument.html
-pub const DEFAULT_MAX_RESPONSE_BYTES: u64 = 2 * (1 << 20);
+// The default value of max_resposne_bytes is 2_000_000.
+pub const DEFAULT_MAX_RESPONSE_BYTES: u64 = 2_000_000;
 
 // Cycles which must be passed with each RPC request in case the
 // third-party JSON-RPC prices increase in the future (currently always refunded)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,15 +1,5 @@
-// HTTP outcall cost calculation
-// See https://internetcomputer.org/docs/current/developer-docs/gas-cost#special-features
+// Constant used in HTTP outcall cost calculation
 pub const INGRESS_OVERHEAD_BYTES: u128 = 100;
-pub const INGRESS_MESSAGE_RECEIVED_COST: u128 = 1_200_000;
-pub const INGRESS_MESSAGE_BYTE_RECEIVED_COST: u128 = 2_000;
-pub const HTTP_OUTCALL_REQUEST_BASE_COST: u128 = 3_000_000;
-pub const HTTP_OUTCALL_REQUEST_PER_NODE_COST: u128 = 60_000;
-pub const HTTP_OUTCALL_REQUEST_COST_PER_BYTE: u128 = 400;
-pub const HTTP_OUTCALL_RESPONSE_COST_PER_BYTE: u128 = 800;
-
-// Additional cost of operating the canister per subnet node
-pub const CANISTER_OVERHEAD: u128 = 1_000_000;
 
 // Cycles which must be passed with each RPC request in case the
 // third-party JSON-RPC prices increase in the future (currently always refunded)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,8 +1,8 @@
 // The default value of max_resposne_bytes is 2_000_000.
 pub const DEFAULT_MAX_RESPONSE_BYTES: u64 = 2_000_000;
 
-// Cycles which must be passed with each RPC request in case the
-// third-party JSON-RPC prices increase in the future (currently always refunded)
+// Cycles (per node) which must be passed with each RPC request
+// as processing fee.
 pub const COLLATERAL_CYCLES_PER_NODE: u128 = 10_000_000;
 
 pub const MINIMUM_WITHDRAWAL_CYCLES: u128 = 1_000_000_000;

--- a/src/http.rs
+++ b/src/http.rs
@@ -13,12 +13,11 @@ use ic_cdk::api::management_canister::http_request::{
 };
 use num_traits::ToPrimitive;
 
-pub async fn json_rpc_request(
+pub fn json_rpc_request_arg(
     service: ResolvedRpcService,
-    rpc_method: MetricRpcMethod,
     json_rpc_payload: &str,
     max_response_bytes: u64,
-) -> RpcResult<HttpResponse> {
+) -> RpcResult<CanisterHttpRequestArgument> {
     let api = service.api(&get_override_provider())?;
     let mut request_headers = api.headers.unwrap_or_default();
     if !request_headers
@@ -30,7 +29,7 @@ pub async fn json_rpc_request(
             value: CONTENT_TYPE_VALUE.to_string(),
         });
     }
-    let request = CanisterHttpRequestArgument {
+    Ok(CanisterHttpRequestArgument {
         url: api.url,
         max_response_bytes: Some(max_response_bytes),
         method: HttpMethod::POST,
@@ -40,7 +39,16 @@ pub async fn json_rpc_request(
             "__transform_json_rpc".to_string(),
             vec![],
         )),
-    };
+    })
+}
+
+pub async fn json_rpc_request(
+    service: ResolvedRpcService,
+    rpc_method: MetricRpcMethod,
+    json_rpc_payload: &str,
+    max_response_bytes: u64,
+) -> RpcResult<HttpResponse> {
+    let request = json_rpc_request_arg(service, json_rpc_payload, max_response_bytes)?;
     http_request(rpc_method, request).await
 }
 
@@ -48,17 +56,7 @@ pub async fn http_request(
     rpc_method: MetricRpcMethod,
     request: CanisterHttpRequestArgument,
 ) -> RpcResult<HttpResponse> {
-    let cycles_cost = get_http_request_cost(
-        get_num_subnet_nodes(),
-        request
-            .body
-            .as_ref()
-            .map(|body| body.len())
-            .unwrap_or_default() as u64,
-        request
-            .max_response_bytes
-            .unwrap_or(DEFAULT_MAX_RESPONSE_BYTES),
-    );
+    let cycles_cost = get_http_request_arg_cost(&request);
     let url = request.url.clone();
     let parsed_url = match url::Url::parse(&url) {
         Ok(url) => url,
@@ -131,4 +129,25 @@ pub fn get_http_response_body(response: HttpResponse) -> Result<String, RpcError
         }
         .into()
     })
+}
+
+pub fn get_http_request_arg_cost(arg: &CanisterHttpRequestArgument) -> u128 {
+    let payload_body_bytes = arg.body.as_ref().map(|body| body.len()).unwrap_or_default();
+    let extra_payload_bytes = arg.url.len()
+        + arg
+            .headers
+            .iter()
+            .map(|header| header.name.len() + header.value.len())
+            .sum::<usize>()
+        + arg.transform.as_ref().map_or(0, |transform| {
+            transform.function.0.method.len() + transform.context.len()
+        });
+    let max_response_bytes = arg.max_response_bytes.unwrap_or(DEFAULT_MAX_RESPONSE_BYTES);
+
+    get_http_request_cost(
+        get_num_subnet_nodes(),
+        payload_body_bytes as u64,
+        extra_payload_bytes as u64,
+        max_response_bytes,
+    )
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -86,7 +86,7 @@ pub async fn http_request(
             }
             .into());
         }
-        ic_cdk::api::call::msg_cycles_accept128(cycles_cost);
+        ic_cdk::api::call::msg_cycles_accept128(cycles_cost_with_collateral);
         add_metric_entry!(
             cycles_charged,
             (rpc_method.clone(), rpc_host.clone()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use candid::candid_method;
+use evm_rpc::accounting::get_cost_with_collateral;
 use evm_rpc::candid_rpc::CandidRpcClient;
 use evm_rpc::http::get_http_response_body;
 use evm_rpc::logs::INFO;
@@ -161,7 +162,10 @@ fn request_cost(
             &json_rpc_payload,
             max_response_bytes,
         )?;
-        Ok(get_http_request_arg_cost(&request))
+        let cycles_cost = get_http_request_arg_cost(&request);
+        let cycles_cost_with_collateral =
+            get_cost_with_collateral(get_num_subnet_nodes(), cycles_cost);
+        Ok(cycles_cost_with_collateral)
     }
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -115,7 +115,7 @@ pub fn next_request_id() -> u64 {
 }
 
 pub fn get_num_subnet_nodes() -> u32 {
-    NUM_SUBNET_NODES.with_borrow(|nodes| nodes.get().clone())
+    NUM_SUBNET_NODES.with_borrow(|state| *state.get())
 }
 
 pub fn set_num_subnet_nodes(nodes: u32) {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -14,6 +14,7 @@ const API_KEY_MAP_MEMORY_ID: MemoryId = MemoryId::new(5);
 const MANAGE_API_KEYS_MEMORY_ID: MemoryId = MemoryId::new(6);
 const LOG_FILTER_MEMORY_ID: MemoryId = MemoryId::new(7);
 const OVERRIDE_PROVIDER_MEMORY_ID: MemoryId = MemoryId::new(8);
+const NUM_SUBNET_NODES_MEMORY_ID: MemoryId = MemoryId::new(9);
 
 type StableMemory = VirtualMemory<DefaultMemoryImpl>;
 
@@ -35,6 +36,8 @@ thread_local! {
         RefCell::new(Cell::init(MEMORY_MANAGER.with_borrow(|m| m.get(LOG_FILTER_MEMORY_ID)), LogFilter::default()).expect("Unable to read log message filter from stable memory"));
     static OVERRIDE_PROVIDER: RefCell<Cell<OverrideProvider, StableMemory>> =
         RefCell::new(Cell::init(MEMORY_MANAGER.with_borrow(|m| m.get(OVERRIDE_PROVIDER_MEMORY_ID)), OverrideProvider::default()).expect("Unable to read provider override from stable memory"));
+    static NUM_SUBNET_NODES: RefCell<Cell<u32, StableMemory>> =
+        RefCell::new(Cell::init(MEMORY_MANAGER.with_borrow(|m| m.get(NUM_SUBNET_NODES_MEMORY_ID)), crate::constants::NODES_IN_SUBNET).expect("Unable to read number of subnet nodes from stable memory"));
 }
 
 pub fn get_api_key(provider_id: ProviderId) -> Option<ApiKey> {
@@ -109,6 +112,18 @@ pub fn next_request_id() -> u64 {
         *counter = counter.wrapping_add(1);
         current_request_id
     })
+}
+
+pub fn get_num_subnet_nodes() -> u32 {
+    NUM_SUBNET_NODES.with_borrow(|nodes| nodes.get().clone())
+}
+
+pub fn set_num_subnet_nodes(nodes: u32) {
+    NUM_SUBNET_NODES.with_borrow_mut(|state| {
+        state
+            .set(nodes)
+            .expect("Error while updating number of subnet nodes")
+    });
 }
 
 #[cfg(test)]

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::accounting::get_http_request_cost;
 use crate::logs::{DEBUG, TRACE_HTTP};
-use crate::memory::{get_override_provider, next_request_id};
+use crate::memory::{get_num_subnet_nodes, get_override_provider, next_request_id};
 use crate::providers::resolve_rpc_service;
 use crate::rpc_client::eth_rpc_error::{sanitize_send_raw_transaction_result, Parser};
 use crate::rpc_client::json::requests::JsonRpcRequest;
@@ -284,6 +284,7 @@ async fn http_request(
     effective_response_size_estimate: u64,
 ) -> Result<HttpResponse, RpcError> {
     let cycles_cost = get_http_request_cost(
+        get_num_subnet_nodes(),
         request
             .body
             .as_ref()

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -1,9 +1,8 @@
-//! This module contains definitions for communicating with an Ethereum API using the [JSON RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+//! This module contains definitions for communicating witEthereum API using the [JSON RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 //! interface.
 
-use crate::accounting::get_http_request_cost;
 use crate::logs::{DEBUG, TRACE_HTTP};
-use crate::memory::{get_num_subnet_nodes, get_override_provider, next_request_id};
+use crate::memory::{get_override_provider, next_request_id};
 use crate::providers::resolve_rpc_service;
 use crate::rpc_client::eth_rpc_error::{sanitize_send_raw_transaction_result, Parser};
 use crate::rpc_client::json::requests::JsonRpcRequest;
@@ -221,7 +220,7 @@ where
             )),
         };
 
-        let response = match http_request(&eth_method, request, effective_size_estimate).await {
+        let response = match http_request(&eth_method, request).await {
             Err(RpcError::HttpOutcallError(HttpOutcallError::IcError { code, message }))
                 if is_response_too_large(&code, &message) =>
             {
@@ -281,19 +280,9 @@ fn resolve_api(
 async fn http_request(
     method: &str,
     request: CanisterHttpRequestArgument,
-    effective_response_size_estimate: u64,
 ) -> Result<HttpResponse, RpcError> {
-    let cycles_cost = get_http_request_cost(
-        get_num_subnet_nodes(),
-        request
-            .body
-            .as_ref()
-            .map(|bytes| bytes.len() as u64)
-            .unwrap_or_default(),
-        effective_response_size_estimate,
-    );
     let rpc_method = MetricRpcMethod(method.to_string());
-    crate::http::http_request(rpc_method, request, cycles_cost).await
+    crate::http::http_request(rpc_method, request).await
 }
 
 fn http_status_code(response: &HttpResponse) -> u16 {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1784,10 +1784,10 @@ fn should_prevent_unknown_provider_update_api_keys() {
 }
 
 #[test]
-fn should_get_notes_in_subnet() {
+fn should_get_nodes_in_subnet() {
     let setup = EvmRpcSetup::new();
     let nodes_in_subnet = setup.get_nodes_in_subnet();
-    assert_eq!(nodes_in_subnet, 34);
+    assert_eq!(nodes_in_subnet, 13);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -94,6 +94,7 @@ impl EvmRpcSetup {
     pub fn new() -> Self {
         Self::with_args(InstallArgs {
             demo: Some(true),
+            nodes_in_subnet: Some(13),
             ..Default::default()
         })
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1041,14 +1041,18 @@ fn candid_rpc_should_err_without_cycles() {
             "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f",
         )
         .wait()
-        .expect_consistent();
-    assert_matches!(
-        result,
-        Err(RpcError::ProviderError(ProviderError::TooFewCycles {
-            expected: _,
-            received: 0,
-        }))
-    );
+        .expect_inconsistent();
+    // Because the expected cycles are different for each provider, the results are inconsistent
+    // but should all be `TooFewCycles` error.
+    for (_, err) in result {
+        assert_matches!(
+            err,
+            Err(RpcError::ProviderError(ProviderError::TooFewCycles {
+                expected: _,
+                received: 0,
+            }))
+        )
+    }
 }
 
 #[test]


### PR DESCRIPTION
XC-257

Fix the cycle computation according to the latest document on the cost for https outcalls https://internetcomputer.org/docs/current/developer-docs/gas-cost/#https-outcalls

Also add `nodesInSubnet` as an optional initialization parameter when creating the EVM RPC canister. It defaults to 34 if not set, which is also the default used previously. 