### PR TITLE
chore: Move Ankr to default ETH Sepolia services

### DIFF
--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -72,12 +72,12 @@ impl Providers {
     ];
 
     const DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] = &[
-        EthSepoliaService::Sepolia,
+        EthSepoliaService::Ankr,
         EthSepoliaService::BlockPi,
         EthSepoliaService::PublicNode,
     ];
     const NON_DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] =
-        &[EthSepoliaService::Alchemy, EthSepoliaService::Ankr];
+        &[EthSepoliaService::Alchemy, EthSepoliaService::Sepolia];
 
     const DEFAULT_L2_MAINNET_SERVICES: &'static [L2MainnetService] = &[
         L2MainnetService::Llama,


### PR DESCRIPTION
([XC-272](https://dfinity.atlassian.net/browse/XC-272)) Move Ankr to default ETH Sepolia services

Since Ankr seems to have fixed their IPv6 compatibility, move it to the list of default ETH Sepolia services, and move rpc.sepolia.org to non-default ETH Sepolia providers.

[XC-272]: https://dfinity.atlassian.net/browse/XC-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ