### PR TITLE
fix: build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           name: evm_rpc.wasm.gz
       
-      - name: Set EVM_RPC_WASM_PATH
+      - name: Set EVM_RPC_WASM_PATH for load_wasm
         run: |
           echo "EVM_RPC_WASM_PATH=$GITHUB_WORKSPACE/evm_rpc.wasm.gz" >> "$GITHUB_ENV"
  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           cargo clippy --tests --benches -- -D clippy::all -D warnings -A clippy::manual_range_contains
 
   cargo-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -48,10 +48,10 @@ jobs:
         uses: arduino/setup-protoc@v3
 
       - name: Cargo test
-        run: unset CI && cargo test -- --test-threads=2
+        run: cargo test -- --test-threads=2 --nocapture
 
-  docker-build:
-    runs-on: ubuntu-latest
+  reproducible-build:
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,25 +31,6 @@ jobs:
           cargo clippy -- -D clippy::all -D warnings -A clippy::manual_range_contains
           cargo clippy --tests --benches -- -D clippy::all -D warnings -A clippy::manual_range_contains
 
-  cargo-test:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
-
-      - name: Install PocketIC server
-        uses: dfinity/pocketic@main
-        with:
-          pocket-ic-server-version: "7.0.0"
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
-      - name: Cargo test
-        run: cargo test -- --test-threads=2 --nocapture
-
   reproducible-build:
     runs-on: ubuntu-22.04
     steps:
@@ -65,11 +46,41 @@ jobs:
         with:
           name: evm_rpc.wasm.gz
           path: evm_rpc.wasm.gz
+          if-no-files-found: error
 
       - name: Add summary
         run: |
           hash=`sha256sum evm_rpc.wasm.gz`
           echo "SHA-256 :hash: ${hash}" >> $GITHUB_STEP_SUMMARY
+
+  cargo-test:
+    needs: [ reproducible-build ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: evm_rpc.wasm.gz
+      
+      - name: Set EVM_RPC_WASM_PATH
+        run: |
+          echo "EVM_RPC_WASM_PATH=$GITHUB_WORKSPACE/evm_rpc.wasm.gz" >> "$GITHUB_ENV"
+ 
+      - name: Install PocketIC server
+        uses: dfinity/pocketic@main
+        with:
+          pocket-ic-server-version: "7.0.0"
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+
+      - name: Cargo test
+        run: cargo test -- --test-threads=2 --nocapture
 
   e2e:
     runs-on: ubuntu-latest
@@ -102,6 +113,6 @@ jobs:
 
       - name: Run local examples with Foundry
         run: scripts/examples evm_rpc_local 'Number = 0'
-      
+
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -22,7 +22,9 @@ use ic_test_utilities_load_wasm::load_wasm;
 use maplit::hashmap;
 use mock::{MockOutcall, MockOutcallBuilder};
 use pocket_ic::common::rest::{CanisterHttpMethod, MockCanisterHttpResponse, RawMessageId};
-use pocket_ic::{management_canister::CanisterSettings, PocketIc, WasmResult};
+use pocket_ic::{
+    management_canister::CanisterSettings, CallError, ErrorCode, PocketIc, UserError, WasmResult,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
@@ -126,18 +128,26 @@ impl EvmRpcSetup {
     }
 
     pub fn upgrade_canister(&self, args: InstallArgs) {
-        self.env.tick();
-        // Avoid `CanisterInstallCodeRateLimited` error
-        self.env.advance_time(Duration::from_secs(600));
-        self.env.tick();
-        self.env
-            .upgrade_canister(
+        for _ in 0..100 {
+            self.env.tick();
+            // Avoid `CanisterInstallCodeRateLimited` error
+            self.env.advance_time(Duration::from_secs(600));
+            self.env.tick();
+            match self.env.upgrade_canister(
                 self.canister_id,
                 evm_rpc_wasm(),
                 Encode!(&args).unwrap(),
                 Some(self.controller),
-            )
-            .expect("Error while upgrading canister");
+            ) {
+                Ok(_) => return,
+                Err(CallError::UserError(UserError {
+                    code: ErrorCode::CanisterInstallCodeRateLimited,
+                    description: _,
+                })) => continue,
+                Err(e) => panic!("Error while upgrading canister: {e:?}"),
+            }
+        }
+        panic!("Failed to upgrade canister after many trials!")
     }
 
     /// Shorthand for deriving an `EvmRpcSetup` with the caller as the canister controller.


### PR DESCRIPTION
1. Change the reproducible build job to use Ubuntu LTS (instead of latest)
2. Use the binary produced by the reproducible build job for integration tests with Pocket IC. Ideally the e2e should also use the same wasm, but this would require changing how `dfx.json` is setup and is out-of-scoped.
3. Run the pipeline 5 times successfully 🎉 .