### PR TITLE
ci: remove protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
       - run: rustup component add clippy
 
       - name: Cargo clippy
@@ -75,9 +72,6 @@ jobs:
           pocket-ic-server-version: "7.0.0"
 
       - uses: Swatinem/rust-cache@v2
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
 
       - name: Cargo test
         run: cargo test -- --test-threads=2 --nocapture


### PR DESCRIPTION
Remove `arduino/setup-protoc@v3` as it is actually not needed and triggers some rate limit.