### PR TITLE
feat: observability layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - v*
     paths-ignore:
       - "README.md"
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+
 jobs:
   cargo-clippy:
     runs-on: ubuntu-latest
@@ -27,6 +31,22 @@ jobs:
         run: |
           cargo clippy -- -D clippy::all -D warnings -A clippy::manual_range_contains
           cargo clippy --tests --benches -- -D clippy::all -D warnings -A clippy::manual_range_contains
+
+  cargo-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: rustup component add clippy
+
+      - name: Cargo doc
+        run: |
+          cargo doc
+        env:
+          RUSTDOCFLAGS: "--deny warnings"
 
   reproducible-build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Cargo doc
         run: |
-          cargo doc
+          cargo doc --workspace --no-deps
         env:
           RUSTDOCFLAGS: "--deny warnings"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "ic-cdk",
  "pin-project",
  "thiserror 2.0.11",
+ "tokio",
  "tower",
 ]
 
@@ -1454,9 +1455,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libredox"
@@ -2984,9 +2985,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3002,9 +3003,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ name = "canhttp"
 version = "0.1.0"
 dependencies = [
  "ic-cdk",
+ "maplit",
  "pin-project",
  "thiserror 2.0.11",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ name = "canhttp"
 version = "0.1.0"
 dependencies = [
  "ic-cdk",
+ "pin-project",
  "thiserror 2.0.11",
  "tower",
 ]
@@ -1873,6 +1874,26 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_bytes = "0.11.15"
 strum = { version = "0.26", features = ["derive"] }
+tokio = "1.43.0"
 tower = "0.5.2"
 thiserror = "2.0.11"
 url = "2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ ic-metrics-encoder = "1.1"
 ic-stable-structures = "0.6.7"
 minicbor = { version = "0.25.1", features = ["alloc", "derive"] }
 num-bigint = "0.4.6"
+pin-project = "1.1.9"
 proptest = "1.6.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ ic-cdk-macros = "0.17.1"
 ic-certified-map = "0.4"
 ic-metrics-encoder = "1.1"
 ic-stable-structures = "0.6.7"
+maplit = "1.0.2"
 minicbor = { version = "0.25.1", features = ["alloc", "derive"] }
 num-bigint = "0.4.6"
 pin-project = "1.1.9"

--- a/canhttp/Cargo.toml
+++ b/canhttp/Cargo.toml
@@ -11,5 +11,6 @@ documentation = "https://docs.rs/canhttp"
 
 [dependencies]
 ic-cdk = { workspace = true }
+pin-project = {workspace = true}
 tower = { workspace = true, features = ["filter", "retry"] }
 thiserror = { workspace = true }

--- a/canhttp/Cargo.toml
+++ b/canhttp/Cargo.toml
@@ -14,3 +14,6 @@ ic-cdk = { workspace = true }
 pin-project = {workspace = true}
 tower = { workspace = true, features = ["filter", "retry"] }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = {workspace = true, features = ["full"]}

--- a/canhttp/Cargo.toml
+++ b/canhttp/Cargo.toml
@@ -16,4 +16,5 @@ tower = { workspace = true, features = ["filter", "retry"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+maplit = {workspace = true}
 tokio = {workspace = true, features = ["full"]}

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -9,6 +9,7 @@ pub use client::{Client, IcError};
 pub use cycles::{
     CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, CyclesCostEstimator,
 };
+pub use observability::ObservabilityLayer;
 
 mod client;
 mod cycles;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -9,8 +9,7 @@ pub use client::{Client, IcError};
 pub use cycles::{
     CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, CyclesCostEstimator,
 };
-pub use observability::{Observability, ObservabilityLayer, RequestObserver, ResponseObserver};
 
 mod client;
 mod cycles;
-mod observability;
+pub mod observability;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -12,3 +12,4 @@ pub use cycles::{
 
 mod client;
 mod cycles;
+mod observability;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -9,7 +9,7 @@ pub use client::{Client, IcError};
 pub use cycles::{
     CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, CyclesCostEstimator,
 };
-pub use observability::ObservabilityLayer;
+pub use observability::{Observability, ObservabilityLayer, RequestObserver, ResponseObserver};
 
 mod client;
 mod cycles;

--- a/canhttp/src/observability/mod.rs
+++ b/canhttp/src/observability/mod.rs
@@ -1,0 +1,208 @@
+use pin_project::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+/// TODO
+pub struct ObservabilityLayer<OnRequest, OnResponse, OnError> {
+    on_request: OnRequest,
+    on_response: OnResponse,
+    on_error: OnError,
+}
+
+impl ObservabilityLayer<(), (), ()> {
+    /// TODO
+    pub fn new() -> Self {
+        Self {
+            on_request: (),
+            on_response: (),
+            on_error: (),
+        }
+    }
+}
+
+impl Default for ObservabilityLayer<(), (), ()> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<OnRequest, OnResponse, OnError> ObservabilityLayer<OnRequest, OnResponse, OnError> {
+    /// TODO
+    pub fn on_request<NewOnRequest>(
+        self,
+        new_on_request: NewOnRequest,
+    ) -> ObservabilityLayer<NewOnRequest, OnResponse, OnError> {
+        ObservabilityLayer {
+            on_request: new_on_request,
+            on_response: self.on_response,
+            on_error: self.on_error,
+        }
+    }
+
+    /// TODO
+    pub fn on_response<NewOnResponse>(
+        self,
+        new_on_response: NewOnResponse,
+    ) -> ObservabilityLayer<OnRequest, NewOnResponse, OnError> {
+        ObservabilityLayer {
+            on_request: self.on_request,
+            on_response: new_on_response,
+            on_error: self.on_error,
+        }
+    }
+
+    /// TODO
+    pub fn on_error<NewOnError>(
+        self,
+        new_on_error: NewOnError,
+    ) -> ObservabilityLayer<OnRequest, OnResponse, NewOnError> {
+        ObservabilityLayer {
+            on_request: self.on_request,
+            on_response: self.on_response,
+            on_error: new_on_error,
+        }
+    }
+}
+
+impl<S, OnRequest, OnResponse, OnError> Layer<S>
+for ObservabilityLayer<OnRequest, OnResponse, OnError>
+where
+    OnRequest: Clone,
+    OnResponse: Clone,
+    OnError: Clone,
+{
+    type Service = Observability<S, OnRequest, OnResponse, OnError>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Self::Service {
+            inner,
+            on_request: self.on_request.clone(),
+            on_response: self.on_response.clone(),
+            on_error: self.on_error.clone(),
+        }
+    }
+}
+
+/// TODO
+pub struct Observability<S, OnRequest, OnResponse, OnError> {
+    inner: S,
+    on_request: OnRequest,
+    on_response: OnResponse,
+    on_error: OnError,
+}
+
+impl<S, Request, Response, OnRequest, RequestData, OnResponse, OnError> Service<Request>
+for Observability<S, OnRequest, OnResponse, OnError>
+where
+    S: Service<Request, Response = Response>,
+    OnRequest: RequestObserver<Request, ObservableRequestData = RequestData>,
+    OnResponse: ResponseObserver<RequestData, S::Response> + Clone,
+    OnError: ResponseObserver<RequestData, S::Error> + Clone,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, RequestData, OnResponse, OnError>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let req_data = self.on_request.observe_request(&req);
+        ResponseFuture {
+            response_future: self.inner.call(req),
+            request_data: Some(req_data),
+            on_response: self.on_response.clone(),
+            on_error: self.on_error.clone(),
+        }
+    }
+}
+
+///TODO
+pub trait ResponseObserver<RequestData, Result> {
+    ///TODO
+    fn observe(&self, request_data: RequestData, value: &Result);
+}
+
+impl<ReqData, Result> ResponseObserver<ReqData, Result> for () {
+    fn observe(&self, _request_data: ReqData, _value: &Result) {
+        //NOP
+    }
+}
+
+impl<F, ReqData, T> ResponseObserver<ReqData, T> for F
+where
+    F: Fn(ReqData, &T),
+{
+    fn observe(&self, request_data: ReqData, value: &T) {
+        self(request_data, value);
+    }
+}
+
+#[pin_project]
+pub struct ResponseFuture<F, RequestData, OnResponse, OnError> {
+    #[pin]
+    response_future: F,
+    request_data: Option<RequestData>,
+    on_response: OnResponse,
+    on_error: OnError,
+}
+
+impl<F, RequestData, OnResponse, OnError, Response, Error> Future
+for ResponseFuture<F, RequestData, OnResponse, OnError>
+where
+    F: Future<Output = Result<Response, Error>>,
+    OnResponse: ResponseObserver<RequestData, Response>,
+    OnError: ResponseObserver<RequestData, Error>,
+{
+    type Output = Result<Response, Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result_fut = this.response_future.poll(cx);
+        match &result_fut {
+            Poll::Ready(result) => {
+                let request_data = this.request_data.take().unwrap();
+                match result {
+                    Ok(response) => {
+                        this.on_response.observe(request_data, response);
+                    }
+                    Err(error) => {
+                        this.on_error.observe(request_data, error);
+                    }
+                }
+            }
+            Poll::Pending => {}
+        }
+        result_fut
+    }
+}
+
+/// TODO
+pub trait RequestObserver<Request> {
+    /// TODO
+    type ObservableRequestData;
+    /// TODO
+    fn observe_request(&self, request: &Request) -> Self::ObservableRequestData;
+}
+
+impl<Request> RequestObserver<Request> for () {
+    type ObservableRequestData = ();
+
+    fn observe_request(&self, _request: &Request) -> Self::ObservableRequestData {
+        //NOP
+    }
+}
+
+impl<F, Request, RequestData> RequestObserver<Request> for F
+where
+    F: Fn(&Request) -> RequestData,
+{
+    type ObservableRequestData = RequestData;
+
+    fn observe_request(&self, request: &Request) -> Self::ObservableRequestData {
+        self(request)
+    }
+}

--- a/canhttp/src/observability/mod.rs
+++ b/canhttp/src/observability/mod.rs
@@ -242,7 +242,7 @@ where
 
 /// Trait used to tell [`Observability`] what to do when a response is received.
 pub trait ResponseObserver<RequestData, Result> {
-    /// Observe the response (typically an instance of [`std::result::Result`] and the request data produced by a [`RequestObserver`].
+    /// Observe the response (typically an instance of [`std::result::Result`]) and the request data produced by a [`RequestObserver`].
     fn observe(&self, request_data: RequestData, value: &Result);
 }
 

--- a/canhttp/src/observability/mod.rs
+++ b/canhttp/src/observability/mod.rs
@@ -67,7 +67,7 @@ impl<OnRequest, OnResponse, OnError> ObservabilityLayer<OnRequest, OnResponse, O
 }
 
 impl<S, OnRequest, OnResponse, OnError> Layer<S>
-for ObservabilityLayer<OnRequest, OnResponse, OnError>
+    for ObservabilityLayer<OnRequest, OnResponse, OnError>
 where
     OnRequest: Clone,
     OnResponse: Clone,
@@ -94,7 +94,7 @@ pub struct Observability<S, OnRequest, OnResponse, OnError> {
 }
 
 impl<S, Request, Response, OnRequest, RequestData, OnResponse, OnError> Service<Request>
-for Observability<S, OnRequest, OnResponse, OnError>
+    for Observability<S, OnRequest, OnResponse, OnError>
 where
     S: Service<Request, Response = Response>,
     OnRequest: RequestObserver<Request, ObservableRequestData = RequestData>,
@@ -151,7 +151,7 @@ pub struct ResponseFuture<F, RequestData, OnResponse, OnError> {
 }
 
 impl<F, RequestData, OnResponse, OnError, Response, Error> Future
-for ResponseFuture<F, RequestData, OnResponse, OnError>
+    for ResponseFuture<F, RequestData, OnResponse, OnError>
 where
     F: Future<Output = Result<Response, Error>>,
     OnResponse: ResponseObserver<RequestData, Response>,

--- a/canhttp/src/observability/mod.rs
+++ b/canhttp/src/observability/mod.rs
@@ -59,7 +59,7 @@
 //! .await?
 //! .call(request)
 //! .await?;
-//! 
+//!
 //! let metrics = METRICS.with_borrow(|m| m.clone());
 //! assert_eq!(
 //!     metrics,

--- a/canhttp/src/observability/mod.rs
+++ b/canhttp/src/observability/mod.rs
@@ -243,11 +243,11 @@ where
 /// Trait used to tell [`Observability`] what to do when a response is received.
 pub trait ResponseObserver<RequestData, Response> {
     /// Observe the response (typically an instance of [`std::result::Result`]) and the request data produced by a [`RequestObserver`].
-    fn observe(&self, request_data: RequestData, value: &Response);
+    fn observe_response(&self, request_data: RequestData, value: &Response);
 }
 
 impl<RequestData, Response> ResponseObserver<RequestData, Response> for () {
-    fn observe(&self, _request_data: RequestData, _value: &Response) {
+    fn observe_response(&self, _request_data: RequestData, _value: &Response) {
         //NOP
     }
 }
@@ -256,7 +256,7 @@ impl<F, RequestData, Response> ResponseObserver<RequestData, Response> for F
 where
     F: Fn(RequestData, &Response),
 {
-    fn observe(&self, request_data: RequestData, value: &Response) {
+    fn observe_response(&self, request_data: RequestData, value: &Response) {
         self(request_data, value);
     }
 }
@@ -288,10 +288,10 @@ where
                 let request_data = this.request_data.take().unwrap();
                 match result {
                     Ok(response) => {
-                        this.on_response.observe(request_data, response);
+                        this.on_response.observe_response(request_data, response);
                     }
                     Err(error) => {
-                        this.on_error.observe(request_data, error);
+                        this.on_error.observe_response(request_data, error);
                     }
                 }
             }

--- a/canhttp/src/observability/mod.rs
+++ b/canhttp/src/observability/mod.rs
@@ -1,10 +1,29 @@
+//! Middleware that adds high level observability (e.g., logging, metrics) to a [`Service`].
+//!
+//! # Comparison with [`tower_http::trace`].
+//! This middleware is strongly inspired by the functionality offered by [`tower_http::trace`].
+//! The reason for not using this middleware directly is it cannot be used inside a canister:
+//! 1. The [`tower_http::Trace`] service measures the latency of a call by calling
+//!     [`Instant::now`](https://github.com/tower-rs/tower-http/blob/469bdac3193ed22da9ea524a454d8cda93ffa0d5/tower-http/src/trace/service.rs#L302),
+//!     which will fail when run from a canister.
+//! 2. The [`tower_http::Trace`] can deal with streaming responses, which is unnecessary for HTTPs outcalls,
+//!     since the response is available to a canister at once. This flexibility brings some complexity
+//!     (body can only be fetched asynchronously, end of stream errors, etc.) which is not useful in a canister environment.
+//!
+//! [`Service`]: tower::Service
+
 use pin_project::pin_project;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tower::{Layer, Service};
 
-/// TODO
+/// [`Layer`] that adds high level observability to a [`Service`].
+///
+/// See the [module docs](crate::observability) for more details.
+///
+/// [`Layer`]: tower::Layer
+/// [`Service`]: tower::Service
 pub struct ObservabilityLayer<OnRequest, OnResponse, OnError> {
     on_request: OnRequest,
     on_response: OnResponse,
@@ -12,7 +31,7 @@ pub struct ObservabilityLayer<OnRequest, OnResponse, OnError> {
 }
 
 impl ObservabilityLayer<(), (), ()> {
-    /// TODO
+    /// Creates a new [`ObservabilityLayer`] that does nothing.
     pub fn new() -> Self {
         Self {
             on_request: (),
@@ -29,7 +48,9 @@ impl Default for ObservabilityLayer<(), (), ()> {
 }
 
 impl<OnRequest, OnResponse, OnError> ObservabilityLayer<OnRequest, OnResponse, OnError> {
-    /// TODO
+    /// Customize what to do when a request is received.
+    ///
+    /// `NewOnRequest` is expected to implement [`RequestObserver`].
     pub fn on_request<NewOnRequest>(
         self,
         new_on_request: NewOnRequest,
@@ -41,7 +62,9 @@ impl<OnRequest, OnResponse, OnError> ObservabilityLayer<OnRequest, OnResponse, O
         }
     }
 
-    /// TODO
+    /// Customize what to do when a response has been produced.
+    ///
+    /// `NewOnResponse` is expected to implement [`ResponseObserver`].
     pub fn on_response<NewOnResponse>(
         self,
         new_on_response: NewOnResponse,
@@ -53,7 +76,9 @@ impl<OnRequest, OnResponse, OnError> ObservabilityLayer<OnRequest, OnResponse, O
         }
     }
 
-    /// TODO
+    /// Customize what to do when an error has been produced.
+    ///
+    /// `NewOnError` is expected to implement [`ResponseObserver`].
     pub fn on_error<NewOnError>(
         self,
         new_on_error: NewOnError,
@@ -85,7 +110,11 @@ where
     }
 }
 
-/// TODO
+/// Middleware that adds high level observability to a [`Service`].
+///
+/// See the [module docs](crate::observability) for an example.
+///
+/// [`Service`]: tower::Service
 pub struct Observability<S, OnRequest, OnResponse, OnError> {
     inner: S,
     on_request: OnRequest,
@@ -120,9 +149,39 @@ where
     }
 }
 
-///TODO
+/// Trait used to tell [`Observability`] what to do when a request is received.
+pub trait RequestObserver<Request> {
+    /// Type of data that can be observed from the request (e.g., URL, host, etc.)
+    /// when the response will be processed.
+    type ObservableRequestData;
+
+    /// Observe the given request and produce observable data based on the request.
+    /// This observable data will be passed on to the response observer.
+    fn observe_request(&self, request: &Request) -> Self::ObservableRequestData;
+}
+
+impl<Request> RequestObserver<Request> for () {
+    type ObservableRequestData = ();
+
+    fn observe_request(&self, _request: &Request) -> Self::ObservableRequestData {
+        //NOP
+    }
+}
+
+impl<F, Request, RequestData> RequestObserver<Request> for F
+where
+    F: Fn(&Request) -> RequestData,
+{
+    type ObservableRequestData = RequestData;
+
+    fn observe_request(&self, request: &Request) -> Self::ObservableRequestData {
+        self(request)
+    }
+}
+
+/// Trait used to tell [`Observability`] what to do when a response is received.
 pub trait ResponseObserver<RequestData, Result> {
-    ///TODO
+    /// Observe the response (typically an instance of [`std::Result`] and the request data produced by a [`RequestObserver`].
     fn observe(&self, request_data: RequestData, value: &Result);
 }
 
@@ -141,6 +200,7 @@ where
     }
 }
 
+/// Response future for [`Observability`].
 #[pin_project]
 pub struct ResponseFuture<F, RequestData, OnResponse, OnError> {
     #[pin]
@@ -177,32 +237,5 @@ where
             Poll::Pending => {}
         }
         result_fut
-    }
-}
-
-/// TODO
-pub trait RequestObserver<Request> {
-    /// TODO
-    type ObservableRequestData;
-    /// TODO
-    fn observe_request(&self, request: &Request) -> Self::ObservableRequestData;
-}
-
-impl<Request> RequestObserver<Request> for () {
-    type ObservableRequestData = ();
-
-    fn observe_request(&self, _request: &Request) -> Self::ObservableRequestData {
-        //NOP
-    }
-}
-
-impl<F, Request, RequestData> RequestObserver<Request> for F
-where
-    F: Fn(&Request) -> RequestData,
-{
-    type ObservableRequestData = RequestData;
-
-    fn observe_request(&self, request: &Request) -> Self::ObservableRequestData {
-        self(request)
     }
 }

--- a/canhttp/src/observability/mod.rs
+++ b/canhttp/src/observability/mod.rs
@@ -11,7 +11,7 @@
 //!     (body can only be fetched asynchronously, end of stream errors, etc.) which is not useful in a canister environment.
 //!
 //! # Examples
-//! 
+//!
 //! To add a basic observability layer, for example tracking the number of request and responses/errors inside a canister:
 //!
 //! ```rust
@@ -241,22 +241,22 @@ where
 }
 
 /// Trait used to tell [`Observability`] what to do when a response is received.
-pub trait ResponseObserver<RequestData, Result> {
+pub trait ResponseObserver<RequestData, Response> {
     /// Observe the response (typically an instance of [`std::result::Result`]) and the request data produced by a [`RequestObserver`].
-    fn observe(&self, request_data: RequestData, value: &Result);
+    fn observe(&self, request_data: RequestData, value: &Response);
 }
 
-impl<ReqData, Result> ResponseObserver<ReqData, Result> for () {
-    fn observe(&self, _request_data: ReqData, _value: &Result) {
+impl<RequestData, Response> ResponseObserver<RequestData, Response> for () {
+    fn observe(&self, _request_data: RequestData, _value: &Response) {
         //NOP
     }
 }
 
-impl<F, ReqData, T> ResponseObserver<ReqData, T> for F
+impl<F, RequestData, Response> ResponseObserver<RequestData, Response> for F
 where
-    F: Fn(ReqData, &T),
+    F: Fn(RequestData, &Response),
 {
-    fn observe(&self, request_data: ReqData, value: &T) {
+    fn observe(&self, request_data: RequestData, value: &Response) {
         self(request_data, value);
     }
 }

--- a/canhttp/src/observability/mod.rs
+++ b/canhttp/src/observability/mod.rs
@@ -1,16 +1,17 @@
 //! Middleware that adds high level observability (e.g., logging, metrics) to a [`Service`].
 //!
-//! # Comparison with [`tower_http::trace`].
-//! This middleware is strongly inspired by the functionality offered by [`tower_http::trace`].
+//! # Comparison with the `Trace` service of the [`tower_http`] crate.
+//! This middleware is strongly inspired by the functionality offered by `Trace`.
 //! The reason for not using this middleware directly is it cannot be used inside a canister:
-//! 1. The [`tower_http::Trace`] service measures the latency of a call by calling
+//! 1. It measures the latency of a call by calling
 //!     [`Instant::now`](https://github.com/tower-rs/tower-http/blob/469bdac3193ed22da9ea524a454d8cda93ffa0d5/tower-http/src/trace/service.rs#L302),
 //!     which will fail when run from a canister.
-//! 2. The [`tower_http::Trace`] can deal with streaming responses, which is unnecessary for HTTPs outcalls,
+//! 2. It can deal with streaming responses, which is unnecessary for HTTPs outcalls,
 //!     since the response is available to a canister at once. This flexibility brings some complexity
 //!     (body can only be fetched asynchronously, end of stream errors, etc.) which is not useful in a canister environment.
 //!
 //! [`Service`]: tower::Service
+//! [`tower_http`]: https://crates.io/crates/tower-http
 
 use pin_project::pin_project;
 use std::future::Future;
@@ -181,7 +182,7 @@ where
 
 /// Trait used to tell [`Observability`] what to do when a response is received.
 pub trait ResponseObserver<RequestData, Result> {
-    /// Observe the response (typically an instance of [`std::Result`] and the request data produced by a [`RequestObserver`].
+    /// Observe the response (typically an instance of [`std::result::Result`] and the request data produced by a [`RequestObserver`].
     fn observe(&self, request_data: RequestData, value: &Result);
 }
 

--- a/evm_rpc_types/src/request/mod.rs
+++ b/evm_rpc_types/src/request/mod.rs
@@ -62,7 +62,7 @@ pub struct GetTransactionCountArgs {
 pub struct CallArgs {
     pub transaction: TransactionRequest,
     /// Integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
-    /// Default to "latest" if unspecified, see https://github.com/ethereum/execution-apis/issues/461.
+    /// Default to "latest" if unspecified, see <https://github.com/ethereum/execution-apis/issues/461>.
     pub block: Option<BlockTag>,
 }
 

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -193,7 +193,7 @@ pub struct Block {
     /// Total difficulty is the sum of all difficulty values up to and including this block.
     ///
     /// Note: this field was removed from the official JSON-RPC specification in
-    /// https://github.com/ethereum/execution-apis/pull/570 and may no longer be served by providers.
+    /// <https://github.com/ethereum/execution-apis/pull/570> and may no longer be served by providers.
     #[serde(rename = "totalDifficulty")]
     pub total_difficulty: Option<Nat256>,
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,5 @@
-use crate::memory::http_client;
+use crate::constants::COLLATERAL_CYCLES_PER_NODE;
+use crate::memory::{get_num_subnet_nodes, is_demo_active};
 use crate::{
     add_metric_entry,
     constants::{CONTENT_TYPE_HEADER_LOWERCASE, CONTENT_TYPE_VALUE},
@@ -6,14 +7,14 @@ use crate::{
     types::{MetricRpcHost, MetricRpcMethod, ResolvedRpcService},
     util::canonicalize_json,
 };
-use canhttp::CyclesAccountingError;
+use canhttp::{CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, ObservabilityLayer};
 use evm_rpc_types::{HttpOutcallError, ProviderError, RpcError, RpcResult, ValidationError};
 use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument, HttpHeader, HttpMethod, HttpResponse, TransformArgs,
     TransformContext,
 };
 use num_traits::ToPrimitive;
-use tower::Service;
+use tower::{BoxError, Service, ServiceBuilder};
 
 pub fn json_rpc_request_arg(
     service: ResolvedRpcService,
@@ -65,7 +66,7 @@ pub async fn http_request(
             return Err(ValidationError::Custom(format!("Error parsing URL: {}", url)).into())
         }
     };
-    let host = match parsed_url.host_str() {
+    let _host = match parsed_url.host_str() {
         Some(host) => host,
         None => {
             return Err(ValidationError::Custom(format!(
@@ -75,39 +76,141 @@ pub async fn http_request(
             .into())
         }
     };
+    http_client(rpc_method).call(request).await
+}
 
-    let rpc_host = MetricRpcHost(host.to_string());
-    add_metric_entry!(requests, (rpc_method.clone(), rpc_host.clone()), 1);
-    match http_client().call(request).await {
-        Ok(response) => {
-            let status: u32 = response.status.0.clone().try_into().unwrap_or(0);
-            add_metric_entry!(responses, (rpc_method, rpc_host, status.into()), 1);
-            Ok(response)
-        }
-        Err(e) => {
-            if let Some(charging_error) = e.downcast_ref::<CyclesAccountingError>() {
-                return match charging_error {
-                    CyclesAccountingError::InsufficientCyclesError { expected, received } => {
-                        Err(ProviderError::TooFewCycles {
-                            expected: *expected,
-                            received: *received,
-                        }
-                        .into())
+pub fn http_client(
+    rpc_method: MetricRpcMethod,
+) -> impl Service<CanisterHttpRequestArgument, Response = HttpResponse, Error = RpcError> {
+    ServiceBuilder::new()
+        .layer(
+            ObservabilityLayer::new()
+                .on_request(move |req: &CanisterHttpRequestArgument| {
+                    let req_data = MetricData::new(rpc_method.clone(), req);
+                    add_metric_entry!(
+                        requests,
+                        (req_data.method.clone(), req_data.host.clone()),
+                        1
+                    );
+                    req_data
+                })
+                .on_response(|req_data: MetricData, response: &HttpResponse| {
+                    let status: u32 = response.status.0.clone().try_into().unwrap_or(0);
+                    add_metric_entry!(
+                        responses,
+                        (req_data.method, req_data.host, status.into()),
+                        1
+                    );
+                })
+                .on_error(|req_data: MetricData, error: &RpcError| {
+                    if let RpcError::HttpOutcallError(HttpOutcallError::IcError {
+                        code,
+                        message: _,
+                    }) = error
+                    {
+                        add_metric_entry!(
+                            err_http_outcall,
+                            (req_data.method, req_data.host, *code),
+                            1
+                        );
                     }
-                };
-            }
-            if let Some(canhttp::IcError { code, message }) = e.downcast_ref::<canhttp::IcError>() {
-                add_metric_entry!(err_http_outcall, (rpc_method, rpc_host, *code), 1);
-                return Err(HttpOutcallError::IcError {
-                    code: *code,
-                    message: message.clone(),
-                }
-                .into());
-            }
-            Err(RpcError::ProviderError(ProviderError::InvalidRpcConfig(
-                format!("Unknown error: {}", e),
-            )))
+                }),
+        )
+        .map_err(map_error)
+        .filter(CyclesAccounting::new(
+            get_num_subnet_nodes(),
+            ChargingPolicyWithCollateral::default(),
+        ))
+        .service(canhttp::Client)
+}
+
+struct MetricData {
+    method: MetricRpcMethod,
+    host: MetricRpcHost,
+}
+
+impl MetricData {
+    pub fn new(method: MetricRpcMethod, request: &CanisterHttpRequestArgument) -> Self {
+        Self {
+            method,
+            host: MetricRpcHost(
+                url::Url::parse(&request.url)
+                    .unwrap()
+                    .host_str()
+                    .unwrap()
+                    .to_string(),
+            ),
         }
+    }
+}
+
+fn map_error(e: BoxError) -> RpcError {
+    if let Some(charging_error) = e.downcast_ref::<CyclesAccountingError>() {
+        return match charging_error {
+            CyclesAccountingError::InsufficientCyclesError { expected, received } => {
+                ProviderError::TooFewCycles {
+                    expected: *expected,
+                    received: *received,
+                }
+                .into()
+            }
+        };
+    }
+    if let Some(canhttp::IcError { code, message }) = e.downcast_ref::<canhttp::IcError>() {
+        // add_metric_entry!(err_http_outcall, (rpc_method, rpc_host, *code), 1);
+        return HttpOutcallError::IcError {
+            code: *code,
+            message: message.clone(),
+        }
+        .into();
+    }
+    RpcError::ProviderError(ProviderError::InvalidRpcConfig(format!(
+        "Unknown error: {}",
+        e
+    )))
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ChargingPolicyWithCollateral {
+    charge_user: bool,
+    collateral_cycles: u128,
+}
+
+impl ChargingPolicyWithCollateral {
+    pub fn new(
+        num_nodes_in_subnet: u32,
+        charge_user: bool,
+        collateral_cycles_per_node: u128,
+    ) -> Self {
+        let collateral_cycles =
+            collateral_cycles_per_node.saturating_mul(num_nodes_in_subnet as u128);
+        Self {
+            charge_user,
+            collateral_cycles,
+        }
+    }
+}
+
+impl Default for ChargingPolicyWithCollateral {
+    fn default() -> Self {
+        Self::new(
+            get_num_subnet_nodes(),
+            !is_demo_active(),
+            COLLATERAL_CYCLES_PER_NODE,
+        )
+    }
+}
+
+impl CyclesChargingPolicy for ChargingPolicyWithCollateral {
+    fn cycles_to_charge(
+        &self,
+        _request: &CanisterHttpRequestArgument,
+        attached_cycles: u128,
+    ) -> u128 {
+        if self.charge_user {
+            return attached_cycles.saturating_add(self.collateral_cycles);
+        }
+        0
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -160,7 +160,6 @@ fn map_error(e: BoxError) -> RpcError {
         };
     }
     if let Some(canhttp::IcError { code, message }) = e.downcast_ref::<canhttp::IcError>() {
-        // add_metric_entry!(err_http_outcall, (rpc_method, rpc_host, *code), 1);
         return HttpOutcallError::IcError {
             code: *code,
             message: message.clone(),

--- a/src/http.rs
+++ b/src/http.rs
@@ -7,7 +7,10 @@ use crate::{
     types::{MetricRpcHost, MetricRpcMethod, ResolvedRpcService},
     util::canonicalize_json,
 };
-use canhttp::{CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, ObservabilityLayer};
+use canhttp::{
+    observability::ObservabilityLayer, CyclesAccounting, CyclesAccountingError,
+    CyclesChargingPolicy,
+};
 use evm_rpc_types::{HttpOutcallError, ProviderError, RpcError, RpcResult, ValidationError};
 use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument, HttpHeader, HttpMethod, HttpResponse, TransformArgs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use candid::candid_method;
 use canhttp::{CyclesChargingPolicy, CyclesCostEstimator};
 use evm_rpc::candid_rpc::CandidRpcClient;
-use evm_rpc::http::get_http_response_body;
+use evm_rpc::http::{get_http_response_body, ChargingPolicyWithCollateral};
 use evm_rpc::logs::INFO;
 use evm_rpc::memory::{
     get_num_subnet_nodes, insert_api_key, is_api_key_principal, is_demo_active, remove_api_key,
     set_api_key_principals, set_demo_active, set_log_filter, set_num_subnet_nodes,
-    set_override_provider, ChargingPolicyWithCollateral,
+    set_override_provider,
 };
 use evm_rpc::metrics::encode_metrics;
 use evm_rpc::providers::{find_provider, resolve_rpc_service, PROVIDERS, SERVICE_PROVIDER_MAP};

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,8 +1,5 @@
-use crate::constants::COLLATERAL_CYCLES_PER_NODE;
 use crate::types::{ApiKey, LogFilter, Metrics, OverrideProvider, ProviderId};
 use candid::Principal;
-use canhttp::{CyclesAccounting, CyclesChargingPolicy};
-use ic_cdk::api::management_canister::http_request::{CanisterHttpRequestArgument, HttpResponse};
 use ic_stable_structures::memory_manager::VirtualMemory;
 use ic_stable_structures::{
     memory_manager::{MemoryId, MemoryManager},
@@ -10,7 +7,6 @@ use ic_stable_structures::{
 };
 use ic_stable_structures::{Cell, StableBTreeMap};
 use std::cell::RefCell;
-use tower::{BoxError, Service, ServiceBuilder};
 
 const IS_DEMO_ACTIVE_MEMORY_ID: MemoryId = MemoryId::new(4);
 const API_KEY_MAP_MEMORY_ID: MemoryId = MemoryId::new(5);
@@ -127,60 +123,6 @@ pub fn set_num_subnet_nodes(nodes: u32) {
             .set(nodes)
             .expect("Error while updating number of subnet nodes")
     });
-}
-
-pub fn http_client(
-) -> impl Service<CanisterHttpRequestArgument, Response = HttpResponse, Error = BoxError> {
-    ServiceBuilder::new()
-        .filter(CyclesAccounting::new(
-            get_num_subnet_nodes(),
-            ChargingPolicyWithCollateral::default(),
-        ))
-        .service(canhttp::Client)
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct ChargingPolicyWithCollateral {
-    charge_user: bool,
-    collateral_cycles: u128,
-}
-
-impl ChargingPolicyWithCollateral {
-    pub fn new(
-        num_nodes_in_subnet: u32,
-        charge_user: bool,
-        collateral_cycles_per_node: u128,
-    ) -> Self {
-        let collateral_cycles =
-            collateral_cycles_per_node.saturating_mul(num_nodes_in_subnet as u128);
-        Self {
-            charge_user,
-            collateral_cycles,
-        }
-    }
-}
-
-impl Default for ChargingPolicyWithCollateral {
-    fn default() -> Self {
-        Self::new(
-            get_num_subnet_nodes(),
-            !is_demo_active(),
-            COLLATERAL_CYCLES_PER_NODE,
-        )
-    }
-}
-
-impl CyclesChargingPolicy for ChargingPolicyWithCollateral {
-    fn cycles_to_charge(
-        &self,
-        _request: &CanisterHttpRequestArgument,
-        attached_cycles: u128,
-    ) -> u128 {
-        if self.charge_user {
-            return attached_cycles.saturating_add(self.collateral_cycles);
-        }
-        0
-    }
 }
 
 #[cfg(test)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1516,6 +1516,39 @@ fn candid_rpc_should_return_inconsistent_results_with_consensus_error() {
 }
 
 #[test]
+fn should_have_metrics_for_generic_request() {
+    use evm_rpc::types::MetricRpcMethod;
+
+    let setup = EvmRpcSetup::new().mock_api_keys();
+    let response = setup
+        .request(
+            RpcService::Custom(RpcApi {
+                url: MOCK_REQUEST_URL.to_string(),
+                headers: None,
+            }),
+            MOCK_REQUEST_PAYLOAD,
+            MOCK_REQUEST_RESPONSE_BYTES,
+        )
+        .mock_http(MockOutcallBuilder::new(200, MOCK_REQUEST_RESPONSE))
+        .wait();
+    assert_eq!(response, Ok(MOCK_REQUEST_RESPONSE.to_string()));
+
+    let rpc_method = || MetricRpcMethod("request".to_string());
+    assert_eq!(
+        setup.get_metrics(),
+        Metrics {
+            requests: hashmap! {
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into()) => 1,
+            },
+            responses: hashmap! {
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into(), 200.into()) => 1,
+            },
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
 fn candid_rpc_should_return_inconsistent_results_with_unexpected_http_status() {
     let setup = EvmRpcSetup::new().mock_api_keys();
     let result = setup


### PR DESCRIPTION
Follow-up on #364 to add a new observability layer to take care of logging and metrics. Unfortunately, [`tower_http::trace`](https://docs.rs/tower-http/latest/tower_http/trace/index.html) cannot be used in a canister environment because it measures call latency with `Instant::now`. The proposed layer, while inspired by [`tower_http::trace`](https://docs.rs/tower-http/latest/tower_http/trace/index.html), is also simpler because it does not have to deal with streaming responses.