### PR TITLE
fix: Reject calls to HTTP endpoint in replicated mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,10 @@ fn post_upgrade(args: evm_rpc_types::InstallArgs) {
 
 #[query(hidden = true)]
 fn http_request(request: http_types::HttpRequest) -> http_types::HttpResponse {
+    if ic_cdk::api::in_replicated_execution() {
+        ic_cdk::trap("Update call rejected");
+    }
+
     match request.path() {
         "/metrics" => {
             let mut writer = MetricsEncoder::new(vec![], ic_cdk::api::time() as i64 / 1_000_000);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -366,23 +366,6 @@ impl EvmRpcSetup {
             .expect("failed to parse EVM_RPC minter log")
             .entries
     }
-
-    pub fn http_update_call(&self) -> WasmResult {
-        let request = HttpRequest {
-            method: "".to_string(),
-            url: "/nonexistent".to_string(),
-            headers: vec![],
-            body: serde_bytes::ByteBuf::new(),
-        };
-        self.env
-            .update_call(
-                self.canister_id,
-                Principal::anonymous(),
-                "http_request",
-                Encode!(&request).unwrap(),
-            )
-            .expect("failed to get canister info")
-    }
 }
 
 pub struct CallFlow<R> {
@@ -2057,8 +2040,21 @@ fn upgrade_should_change_manage_api_key_principals() {
 #[test]
 #[should_panic(expected = "Update call rejected")]
 fn should_reject_http_request_in_replicated_mode() {
-    let setup = EvmRpcSetup::new();
-    setup.http_update_call();
+    let request = HttpRequest {
+        method: "".to_string(),
+        url: "/nonexistent".to_string(),
+        headers: vec![],
+        body: serde_bytes::ByteBuf::new(),
+    };
+    EvmRpcSetup::new()
+        .env
+        .update_call(
+            EvmRpcSetup::new().canister_id,
+            Principal::anonymous(),
+            "http_request",
+            Encode!(&request).unwrap(),
+        )
+        .expect("failed to get canister info");
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2038,7 +2038,6 @@ fn upgrade_should_change_manage_api_key_principals() {
 }
 
 #[test]
-#[should_panic(expected = "Update call rejected")]
 fn should_reject_http_request_in_replicated_mode() {
     let request = HttpRequest {
         method: "".to_string(),
@@ -2046,15 +2045,17 @@ fn should_reject_http_request_in_replicated_mode() {
         headers: vec![],
         body: serde_bytes::ByteBuf::new(),
     };
-    EvmRpcSetup::new()
+    assert_matches!(
+        EvmRpcSetup::new()
         .env
         .update_call(
             EvmRpcSetup::new().canister_id,
             Principal::anonymous(),
             "http_request",
             Encode!(&request).unwrap(),
-        )
-        .expect("failed to get canister info");
+        ),
+        Err(e) if e.code == ErrorCode::CanisterCalledTrap && e.description.contains("Update call rejected")
+    );
 }
 
 #[test]


### PR DESCRIPTION
Ensure that calls to the HTTP endpoint in the EVM RPC canister in replicated mode are rejected.