### PR TITLE
feat: JSON RPC conversion layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Cargo doc
         run: |
-          cargo doc --workspace --no-deps
+          cargo doc --workspace --no-deps --all-features
         env:
           RUSTDOCFLAGS: "--deny warnings"
 
@@ -94,7 +94,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cargo test
-        run: cargo test --workspace -- --test-threads=2 --nocapture
+        run: cargo test --workspace --all-features -- --test-threads=2 --nocapture
 
   e2e:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "thiserror 2.0.11",
  "thousands",
  "tower",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,8 @@ dependencies = [
  "maplit",
  "num-traits",
  "pin-project",
+ "serde",
+ "serde_json",
  "thiserror 2.0.11",
  "tokio",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "candid",
+ "futures-util",
  "http",
  "ic-cdk",
  "maplit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ inherits = "release"
 
 [dependencies]
 candid = { workspace = true }
-canhttp = { path = "canhttp" }
+canhttp = { path = "canhttp", features = ["json"] }
 ethnum = { workspace = true }
 evm_rpc_types = { path = "evm_rpc_types" }
 futures = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ candid = { version = "0.10.13" }
 candid_parser = {version = "0.1.4"}
 ethnum = { version = "1.5.0", features = ["serde"] }
 futures = "0.3.31"
+futures-util = "0.3.31"
 getrandom = { version = "0.2", features = ["custom"] }
 hex = "0.4.3"
 http = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,10 @@ minicbor = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 thousands = "0.2"
-tower = {workspace = true}
-tower-http = {workspace = true, features = ["set-header", "util"]}
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["set-header", "util"] }
 url = { workspace = true }
 hex = "0.4"
 ethers-core = "2.0"
@@ -59,7 +60,7 @@ rand = "0.8"
 [workspace.dependencies]
 assert_matches = "1.5.0"
 candid = { version = "0.10.13" }
-candid_parser = {version = "0.1.4"}
+candid_parser = { version = "0.1.4" }
 ethnum = { version = "1.5.0", features = ["serde"] }
 futures = "0.3.31"
 futures-util = "0.3.31"
@@ -91,4 +92,4 @@ thiserror = "2.0.11"
 url = "2.5"
 
 [workspace]
-members = [ "canhttp", "e2e/rust", "evm_rpc_types"]
+members = ["canhttp", "e2e/rust", "evm_rpc_types"]

--- a/canhttp/Cargo.toml
+++ b/canhttp/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/canhttp"
 
 [dependencies]
 ic-cdk = { workspace = true }
+futures-util = {workspace = true}
 http = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
 pin-project = { workspace = true }

--- a/canhttp/Cargo.toml
+++ b/canhttp/Cargo.toml
@@ -14,6 +14,8 @@ ic-cdk = { workspace = true }
 http = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
 pin-project = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 tower = { workspace = true, features = ["filter", "retry"] }
 tower-layer = { workspace = true, optional = true }
 thiserror = { workspace = true }
@@ -27,3 +29,4 @@ tokio = { workspace = true, features = ["full"] }
 [features]
 default = ["http"]
 http = ["dep:http", "dep:num-traits", "dep:tower-layer"]
+json = ["dep:serde", "dep:serde_json"]

--- a/canhttp/Cargo.toml
+++ b/canhttp/Cargo.toml
@@ -29,4 +29,4 @@ tokio = { workspace = true, features = ["full"] }
 [features]
 default = ["http"]
 http = ["dep:http", "dep:num-traits", "dep:tower-layer"]
-json = ["dep:serde", "dep:serde_json"]
+json = ["http", "dep:serde", "dep:serde_json"]

--- a/canhttp/Cargo.toml
+++ b/canhttp/Cargo.toml
@@ -11,13 +11,13 @@ documentation = "https://docs.rs/canhttp"
 
 [dependencies]
 ic-cdk = { workspace = true }
-futures-util = {workspace = true}
+futures-util = { workspace = true }
 http = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
 pin-project = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-tower = { workspace = true, features = ["filter", "retry"] }
+tower = { workspace = true, features = ["retry"] }
 tower-layer = { workspace = true, optional = true }
 thiserror = { workspace = true }
 

--- a/canhttp/src/client/mod.rs
+++ b/canhttp/src/client/mod.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use thiserror::Error;
-use tower::Service;
+use tower::{Service, ServiceBuilder};
 
 /// Thin wrapper around [`ic_cdk::api::management_canister::http_request::http_request`]
 /// that implements the [`tower::Service`] trait. Its functionality can be extended by composing so-called
@@ -18,6 +18,15 @@ use tower::Service;
 /// * [`crate::http`]: use types from the [http](https://crates.io/crates/http) crate for requests and responses.
 #[derive(Clone, Debug)]
 pub struct Client;
+
+impl Client {
+    pub fn new<CustomError: From<IcError>>(
+    ) -> impl Service<IcHttpRequestWithCycles, Response = IcHttpResponse, Error = CustomError> {
+        ServiceBuilder::new()
+            .map_err(CustomError::from)
+            .service(Client)
+    }
+}
 
 /// Error returned by the Internet Computer when making an HTTPs outcall.
 #[derive(Error, Clone, Debug, PartialEq, Eq)]

--- a/canhttp/src/client/mod.rs
+++ b/canhttp/src/client/mod.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use thiserror::Error;
-use tower::{Service, ServiceBuilder};
+use tower::{BoxError, Service, ServiceBuilder};
 
 /// Thin wrapper around [`ic_cdk::api::management_canister::http_request::http_request`]
 /// that implements the [`tower::Service`] trait. Its functionality can be extended by composing so-called
@@ -20,11 +20,16 @@ use tower::{Service, ServiceBuilder};
 pub struct Client;
 
 impl Client {
-    pub fn new<CustomError: From<IcError>>(
+    pub fn new_with_error<CustomError: From<IcError>>(
     ) -> impl Service<IcHttpRequestWithCycles, Response = IcHttpResponse, Error = CustomError> {
         ServiceBuilder::new()
             .map_err(CustomError::from)
             .service(Client)
+    }
+
+    pub fn new_with_box_error(
+    ) -> impl Service<IcHttpRequestWithCycles, Response = IcHttpResponse, Error = BoxError> {
+        Self::new_with_error::<BoxError>()
     }
 }
 

--- a/canhttp/src/client/mod.rs
+++ b/canhttp/src/client/mod.rs
@@ -20,6 +20,7 @@ use tower::{BoxError, Service, ServiceBuilder};
 pub struct Client;
 
 impl Client {
+    /// Create a new client returning custom errors.
     pub fn new_with_error<CustomError: From<IcError>>(
     ) -> impl Service<IcHttpRequestWithCycles, Response = IcHttpResponse, Error = CustomError> {
         ServiceBuilder::new()
@@ -27,6 +28,7 @@ impl Client {
             .service(Client)
     }
 
+    /// Creates a new client where error type is erased.
     pub fn new_with_box_error(
     ) -> impl Service<IcHttpRequestWithCycles, Response = IcHttpResponse, Error = BoxError> {
         Self::new_with_error::<BoxError>()
@@ -78,8 +80,11 @@ impl Service<IcHttpRequestWithCycles> for Client {
     }
 }
 
+/// [`IcHttpRequest`] specifying how many cycles should be attached for the HTTPs outcall.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct IcHttpRequestWithCycles {
+    /// Request to be made.
     pub request: IcHttpRequest,
+    /// Number of cycles to attach.
     pub cycles: u128,
 }

--- a/canhttp/src/convert/mod.rs
+++ b/canhttp/src/convert/mod.rs
@@ -1,98 +1,17 @@
-use futures_util::future;
-use pin_project::pin_project;
-use std::fmt::Debug;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use tower::{Service, ServiceBuilder};
-use tower_layer::{Layer, Stack};
+pub use request::{ConvertRequest, ConvertRequestLayer};
+pub use response::{ConvertResponse, ConvertResponseLayer};
+
+mod request;
+mod response;
+
+use tower::ServiceBuilder;
+use tower_layer::Stack;
 
 pub trait Convert<Input> {
     type Output;
     type Error;
 
     fn try_convert(&mut self, response: Input) -> Result<Self::Output, Self::Error>;
-}
-
-#[derive(Debug, Clone)]
-pub struct ConvertResponseLayer<C> {
-    converter: C,
-}
-
-impl<C> ConvertResponseLayer<C> {
-    pub fn new(converter: C) -> Self {
-        Self { converter }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ConvertResponse<S, C> {
-    inner: S,
-    converter: C,
-}
-
-impl<S, C: Clone> Layer<S> for ConvertResponseLayer<C> {
-    type Service = ConvertResponse<S, C>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        Self::Service {
-            inner,
-            converter: self.converter.clone(),
-        }
-    }
-}
-
-impl<S, Request, Response, NewResponse, Converter> Service<Request>
-    for ConvertResponse<S, Converter>
-where
-    S: Service<Request, Response = Response>,
-    Converter: Convert<Response, Output = NewResponse> + Clone,
-    Converter::Error: Into<S::Error>,
-{
-    type Response = NewResponse;
-    type Error = S::Error;
-    type Future = ResponseFuture<S::Future, Converter>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, req: Request) -> Self::Future {
-        ResponseFuture {
-            response_future: self.inner.call(req),
-            converter: self.converter.clone(),
-        }
-    }
-}
-
-#[pin_project]
-pub struct ResponseFuture<F, Converter> {
-    #[pin]
-    response_future: F,
-    converter: Converter,
-}
-
-impl<F, Filter, Response, NewResponse, Error> Future for ResponseFuture<F, Filter>
-where
-    F: Future<Output = Result<Response, Error>>,
-    Filter: Convert<Response, Output = NewResponse>,
-    Filter::Error: Into<Error>,
-{
-    type Output = Result<NewResponse, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        let result_fut = this.response_future.poll(cx);
-        match result_fut {
-            Poll::Ready(result) => match result {
-                Ok(response) => {
-                    Poll::Ready(this.converter.try_convert(response).map_err(Into::into))
-                }
-                Err(err) => Poll::Ready(Err(err)),
-            },
-            Poll::Pending => Poll::Pending,
-        }
-    }
 }
 
 pub trait ConvertServiceBuilder<L> {
@@ -102,63 +21,13 @@ pub trait ConvertServiceBuilder<L> {
 
 impl<L> ConvertServiceBuilder<L> for ServiceBuilder<L> {
     fn convert_request<C>(self, converter: C) -> ServiceBuilder<Stack<ConvertRequestLayer<C>, L>> {
-        self.layer(ConvertRequestLayer { converter })
+        self.layer(ConvertRequestLayer::new(converter))
     }
 
     fn convert_response<C>(
         self,
         converter: C,
     ) -> ServiceBuilder<Stack<ConvertResponseLayer<C>, L>> {
-        self.layer(ConvertResponseLayer { converter })
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ConvertRequestLayer<C> {
-    converter: C,
-}
-
-impl<C> ConvertRequestLayer<C> {
-    pub fn new(converter: C) -> Self {
-        Self { converter }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ConvertRequest<S, C> {
-    inner: S,
-    converter: C,
-}
-
-impl<S, C: Clone> Layer<S> for ConvertRequestLayer<C> {
-    type Service = ConvertRequest<S, C>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        Self::Service {
-            inner,
-            converter: self.converter.clone(),
-        }
-    }
-}
-
-impl<S, Converter, Request, NewRequest, Error> Service<NewRequest> for ConvertRequest<S, Converter>
-where
-    Converter: Convert<NewRequest, Output = Request>,
-    S: Service<Request, Error = Error>,
-    Converter::Error: Into<Error>,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = future::Either<S::Future, future::Ready<Result<S::Response, S::Error>>>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, new_req: NewRequest) -> Self::Future {
-        match self.converter.try_convert(new_req) {
-            Ok(request) => future::Either::Left(self.inner.call(request)),
-            Err(err) => future::Either::Right(future::ready(Err(err.into()))),
-        }
+        self.layer(ConvertResponseLayer::new(converter))
     }
 }

--- a/canhttp/src/convert/mod.rs
+++ b/canhttp/src/convert/mod.rs
@@ -1,16 +1,16 @@
 //! Fallible conversion from one type to another that can be used as a tower middleware.
 //!
 //! # Examples
-//! 
+//!
 //! ## To convert requests
 //!
 //! A converter can be used to convert request types:
 //! * If the result of the conversion is [`Ok`], the converted type will be forwarded to the inner service.
 //! * If the result of the conversion is [`Err`], the error will be returned and the inner service will *not* be called.
-//! 
-//! When used to convert requests (with [`ConvertRequestLayer`], the functionality offered by [`Convert`] is similar to that of 
+//!
+//! When used to convert requests (with [`ConvertRequestLayer`], the functionality offered by [`Convert`] is similar to that of
 //! [`Predicate`](https://docs.rs/tower/0.5.2/tower/filter/trait.Predicate.html) in that it can act as a *filter*. The main difference is that the error does not need to be boxed.
-//! 
+//!
 //! ```rust
 //! use std::convert::Infallible;
 //! use canhttp::convert::{Convert, ConvertServiceBuilder};
@@ -52,9 +52,9 @@
 //! # Ok(())
 //! # }
 //! ```
-//! 
+//!
 //! ## To convert responses
-//! 
+//!
 //! A converter can be used to convert response types:
 //! ```rust
 //! use std::convert::Infallible;

--- a/canhttp/src/convert/mod.rs
+++ b/canhttp/src/convert/mod.rs
@@ -1,3 +1,104 @@
+//! Fallible conversion from one type to another that can be used as a tower middleware.
+//!
+//! # Examples
+//! 
+//! ## To convert requests
+//!
+//! A converter can be used to convert request types:
+//! * If the result of the conversion is [`Ok`], the converted type will be forwarded to the inner service.
+//! * If the result of the conversion is [`Err`], the error will be returned and the inner service will *not* be called.
+//! 
+//! When used to convert requests (with [`ConvertRequestLayer`], the functionality offered by [`Convert`] is similar to that of 
+//! [`Predicate`](https://docs.rs/tower/0.5.2/tower/filter/trait.Predicate.html) in that it can act as a *filter*. The main difference is that the error does not need to be boxed.
+//! 
+//! ```rust
+//! use std::convert::Infallible;
+//! use canhttp::convert::{Convert, ConvertServiceBuilder};
+//! use tower::{ServiceBuilder, Service, ServiceExt};
+//!
+//!  async fn bare_bone_service(request: Vec<u8>) -> Result<Vec<u8>, Infallible> {
+//!    Ok(request)
+//!  }
+//!
+//! struct UsefulRequest(Vec<u8>);
+//!
+//! #[derive(Clone)]
+//! struct UsefulRequestConverter;
+//!
+//! impl Convert<UsefulRequest> for UsefulRequestConverter {
+//!     type Output = Vec<u8>;
+//!     type Error = Infallible;
+//!
+//!     fn try_convert(&mut self, input: UsefulRequest) -> Result<Self::Output, Self::Error> {
+//!         Ok(input.0)
+//!     }
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut service = ServiceBuilder::new()
+//!     .convert_request(UsefulRequestConverter)
+//!     .service_fn(bare_bone_service);
+//!
+//! let request = UsefulRequest(vec![42]);
+//!
+//! let response = service
+//!     .ready()
+//!     .await?
+//!     .call(request)
+//!     .await?;
+//!
+//! assert_eq!(response, vec![42_u8]);
+//! # Ok(())
+//! # }
+//! ```
+//! 
+//! ## To convert responses
+//! 
+//! A converter can be used to convert response types:
+//! ```rust
+//! use std::convert::Infallible;
+//! use canhttp::convert::{Convert, ConvertServiceBuilder};
+//! use tower::{ServiceBuilder, Service, ServiceExt};
+//!
+//!  async fn bare_bone_service(request: Vec<u8>) -> Result<Vec<u8>, Infallible> {
+//!    Ok(request)
+//!  }
+//!
+//! #[derive(Debug, PartialEq)]
+//! struct UsefulResponse(Vec<u8>);
+//!
+//! #[derive(Clone)]
+//! struct UsefulResponseConverter;
+//!
+//! impl Convert<Vec<u8>> for UsefulResponseConverter {
+//!     type Output = UsefulResponse;
+//!     type Error = Infallible;
+//!
+//!     fn try_convert(&mut self, input: Vec<u8>) -> Result<Self::Output, Self::Error> {
+//!         Ok(UsefulResponse(input))
+//!     }
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut service = ServiceBuilder::new()
+//!     .convert_response(UsefulResponseConverter)
+//!     .service_fn(bare_bone_service);
+//!
+//! let request = vec![42];
+//!
+//! let response = service
+//!     .ready()
+//!     .await?
+//!     .call(request)
+//!     .await?;
+//!
+//! assert_eq!(response, UsefulResponse(vec![42_u8]));
+//! # Ok(())
+//! # }
+//! ```
+
 pub use request::{ConvertRequest, ConvertRequestLayer};
 pub use response::{ConvertResponse, ConvertResponseLayer};
 
@@ -7,15 +108,29 @@ mod response;
 use tower::ServiceBuilder;
 use tower_layer::Stack;
 
+/// Fallible conversion from one type to another.
 pub trait Convert<Input> {
+    /// Converted type if the conversion succeeds.
     type Output;
+    /// Error type if the conversion fails
     type Error;
 
+    /// Try to convert an instance of the input type to the output type.
+    /// The conversion may fail, in which case an error is returned.
     fn try_convert(&mut self, response: Input) -> Result<Self::Output, Self::Error>;
 }
 
+/// Extension trait that adds methods to [`tower::ServiceBuilder`] for adding middleware
+/// based on fallible conversion between types.
 pub trait ConvertServiceBuilder<L> {
+    /// Convert the request type.
+    ///
+    /// See the [module docs](crate::convert) for examples.
     fn convert_request<C>(self, f: C) -> ServiceBuilder<Stack<ConvertRequestLayer<C>, L>>;
+
+    /// Convert the response type.
+    ///
+    /// See the [module docs](crate::convert) for examples.
     fn convert_response<C>(self, f: C) -> ServiceBuilder<Stack<ConvertResponseLayer<C>, L>>;
 }
 

--- a/canhttp/src/convert/mod.rs
+++ b/canhttp/src/convert/mod.rs
@@ -1,4 +1,4 @@
-use futures_util::future::Either;
+use futures_util::future;
 use pin_project::pin_project;
 use std::fmt::Debug;
 use std::future::Future;
@@ -15,36 +15,37 @@ pub trait Convert<Input> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ConvertResponseLayer<F> {
-    filter: F,
+pub struct ConvertResponseLayer<C> {
+    converter: C,
 }
 
 #[derive(Debug, Clone)]
-pub struct ConvertResponse<S, F> {
+pub struct ConvertResponse<S, C> {
     inner: S,
-    filter: F,
+    converter: C,
 }
 
-impl<S, F: Clone> Layer<S> for ConvertResponseLayer<F> {
-    type Service = ConvertResponse<S, F>;
+impl<S, C: Clone> Layer<S> for ConvertResponseLayer<C> {
+    type Service = ConvertResponse<S, C>;
 
     fn layer(&self, inner: S) -> Self::Service {
         Self::Service {
             inner,
-            filter: self.filter.clone(),
+            converter: self.converter.clone(),
         }
     }
 }
 
-impl<S, Request, Response, NewResponse, F> Service<Request> for ConvertResponse<S, F>
+impl<S, Request, Response, NewResponse, Converter> Service<Request>
+    for ConvertResponse<S, Converter>
 where
     S: Service<Request, Response = Response>,
-    F: Convert<Response, Output = NewResponse> + Clone,
-    F::Error: Into<S::Error>,
+    Converter: Convert<Response, Output = NewResponse> + Clone,
+    Converter::Error: Into<S::Error>,
 {
     type Response = NewResponse;
     type Error = S::Error;
-    type Future = ResponseFuture<S::Future, F>;
+    type Future = ResponseFuture<S::Future, Converter>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
@@ -53,16 +54,16 @@ where
     fn call(&mut self, req: Request) -> Self::Future {
         ResponseFuture {
             response_future: self.inner.call(req),
-            filter: self.filter.clone(),
+            converter: self.converter.clone(),
         }
     }
 }
 
 #[pin_project]
-pub struct ResponseFuture<F, Filter> {
+pub struct ResponseFuture<F, Converter> {
     #[pin]
     response_future: F,
-    filter: Filter,
+    converter: Converter,
 }
 
 impl<F, Filter, Response, NewResponse, Error> Future for ResponseFuture<F, Filter>
@@ -78,7 +79,9 @@ where
         let result_fut = this.response_future.poll(cx);
         match result_fut {
             Poll::Ready(result) => match result {
-                Ok(response) => Poll::Ready(this.filter.try_convert(response).map_err(Into::into)),
+                Ok(response) => {
+                    Poll::Ready(this.converter.try_convert(response).map_err(Into::into))
+                }
                 Err(err) => Poll::Ready(Err(err)),
             },
             Poll::Pending => Poll::Pending,
@@ -87,60 +90,63 @@ where
 }
 
 pub trait ConvertServiceBuilder<L> {
-    fn convert_request<F>(self, f: F) -> ServiceBuilder<Stack<ConvertRequestLayer<F>, L>>;
-    fn convert_response<F>(self, f: F) -> ServiceBuilder<Stack<ConvertResponseLayer<F>, L>>;
+    fn convert_request<C>(self, f: C) -> ServiceBuilder<Stack<ConvertRequestLayer<C>, L>>;
+    fn convert_response<C>(self, f: C) -> ServiceBuilder<Stack<ConvertResponseLayer<C>, L>>;
 }
 
 impl<L> ConvertServiceBuilder<L> for ServiceBuilder<L> {
-    fn convert_request<F>(self, f: F) -> ServiceBuilder<Stack<ConvertRequestLayer<F>, L>> {
-        self.layer(ConvertRequestLayer { filter: f })
+    fn convert_request<C>(self, converter: C) -> ServiceBuilder<Stack<ConvertRequestLayer<C>, L>> {
+        self.layer(ConvertRequestLayer { converter })
     }
 
-    fn convert_response<F>(self, f: F) -> ServiceBuilder<Stack<ConvertResponseLayer<F>, L>> {
-        self.layer(ConvertResponseLayer { filter: f })
+    fn convert_response<C>(
+        self,
+        converter: C,
+    ) -> ServiceBuilder<Stack<ConvertResponseLayer<C>, L>> {
+        self.layer(ConvertResponseLayer { converter })
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct ConvertRequestLayer<F> {
-    filter: F,
+pub struct ConvertRequestLayer<C> {
+    converter: C,
 }
 
 #[derive(Debug, Clone)]
-pub struct ConvertRequest<S, F> {
+pub struct ConvertRequest<S, C> {
     inner: S,
-    filter: F,
+    converter: C,
 }
 
-impl<S, F: Clone> Layer<S> for ConvertRequestLayer<F> {
-    type Service = ConvertRequest<S, F>;
+impl<S, C: Clone> Layer<S> for ConvertRequestLayer<C> {
+    type Service = ConvertRequest<S, C>;
 
     fn layer(&self, inner: S) -> Self::Service {
         Self::Service {
             inner,
-            filter: self.filter.clone(),
+            converter: self.converter.clone(),
         }
     }
 }
 
-impl<S, F, Request, NewRequest, Error> Service<NewRequest> for ConvertRequest<S, F>
+impl<S, Converter, Request, NewRequest, Error> Service<NewRequest> for ConvertRequest<S, Converter>
 where
-    F: Convert<NewRequest, Output = Request>,
+    Converter: Convert<NewRequest, Output = Request>,
     S: Service<Request, Error = Error>,
-    F::Error: Into<Error>,
+    Converter::Error: Into<Error>,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = Either<S::Future, futures_util::future::Ready<Result<S::Response, S::Error>>>;
+    type Future = future::Either<S::Future, future::Ready<Result<S::Response, S::Error>>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, new_req: NewRequest) -> Self::Future {
-        match self.filter.try_convert(new_req) {
-            Ok(request) => Either::Left(self.inner.call(request)),
-            Err(err) => Either::Right(futures_util::future::ready(Err(err.into()))),
+        match self.converter.try_convert(new_req) {
+            Ok(request) => future::Either::Left(self.inner.call(request)),
+            Err(err) => future::Either::Right(future::ready(Err(err.into()))),
         }
     }
 }

--- a/canhttp/src/convert/mod.rs
+++ b/canhttp/src/convert/mod.rs
@@ -19,6 +19,12 @@ pub struct ConvertResponseLayer<C> {
     converter: C,
 }
 
+impl<C> ConvertResponseLayer<C> {
+    pub fn new(converter: C) -> Self {
+        Self { converter }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ConvertResponse<S, C> {
     inner: S,
@@ -110,6 +116,12 @@ impl<L> ConvertServiceBuilder<L> for ServiceBuilder<L> {
 #[derive(Debug, Clone)]
 pub struct ConvertRequestLayer<C> {
     converter: C,
+}
+
+impl<C> ConvertRequestLayer<C> {
+    pub fn new(converter: C) -> Self {
+        Self { converter }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/canhttp/src/convert/request.rs
+++ b/canhttp/src/convert/request.rs
@@ -4,17 +4,25 @@ use std::task::{Context, Poll};
 use tower::Service;
 use tower_layer::Layer;
 
+/// Convert request of a service into another type, where the conversion may fail.
+///
+/// This [`Layer`] produces instances of the [`ConvertRequest`] service.
+///
+/// [`Layer`]: tower::Layer
 #[derive(Debug, Clone)]
 pub struct ConvertRequestLayer<C> {
     converter: C,
 }
 
 impl<C> ConvertRequestLayer<C> {
+    /// Returns a new [`ConvertRequestLayer`]
     pub fn new(converter: C) -> Self {
         Self { converter }
     }
 }
 
+/// Convert requests into another type and forward the converted type to the inner service
+/// *only if* the conversion was successful.
 #[derive(Debug, Clone)]
 pub struct ConvertRequest<S, C> {
     inner: S,

--- a/canhttp/src/convert/request.rs
+++ b/canhttp/src/convert/request.rs
@@ -1,0 +1,55 @@
+use crate::convert::Convert;
+use futures_util::future;
+use std::task::{Context, Poll};
+use tower::Service;
+use tower_layer::Layer;
+
+#[derive(Debug, Clone)]
+pub struct ConvertRequestLayer<C> {
+    converter: C,
+}
+
+impl<C> ConvertRequestLayer<C> {
+    pub fn new(converter: C) -> Self {
+        Self { converter }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConvertRequest<S, C> {
+    inner: S,
+    converter: C,
+}
+
+impl<S, C: Clone> Layer<S> for ConvertRequestLayer<C> {
+    type Service = ConvertRequest<S, C>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Self::Service {
+            inner,
+            converter: self.converter.clone(),
+        }
+    }
+}
+
+impl<S, Converter, Request, NewRequest, Error> Service<NewRequest> for ConvertRequest<S, Converter>
+where
+    Converter: Convert<NewRequest, Output = Request>,
+    S: Service<Request, Error = Error>,
+    Converter::Error: Into<Error>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = future::Either<S::Future, future::Ready<Result<S::Response, S::Error>>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, new_req: NewRequest) -> Self::Future {
+        match self.converter.try_convert(new_req) {
+            Ok(request) => future::Either::Left(self.inner.call(request)),
+            Err(err) => future::Either::Right(future::ready(Err(err.into()))),
+        }
+    }
+}

--- a/canhttp/src/convert/response.rs
+++ b/canhttp/src/convert/response.rs
@@ -1,0 +1,87 @@
+use crate::convert::Convert;
+use pin_project::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::Service;
+use tower_layer::Layer;
+
+#[derive(Debug, Clone)]
+pub struct ConvertResponseLayer<C> {
+    converter: C,
+}
+
+impl<C> ConvertResponseLayer<C> {
+    pub fn new(converter: C) -> Self {
+        Self { converter }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConvertResponse<S, C> {
+    inner: S,
+    converter: C,
+}
+
+impl<S, C: Clone> Layer<S> for ConvertResponseLayer<C> {
+    type Service = ConvertResponse<S, C>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Self::Service {
+            inner,
+            converter: self.converter.clone(),
+        }
+    }
+}
+
+impl<S, Request, Response, NewResponse, Converter> Service<Request>
+    for ConvertResponse<S, Converter>
+where
+    S: Service<Request, Response = Response>,
+    Converter: Convert<Response, Output = NewResponse> + Clone,
+    Converter::Error: Into<S::Error>,
+{
+    type Response = NewResponse;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, Converter>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        ResponseFuture {
+            response_future: self.inner.call(req),
+            converter: self.converter.clone(),
+        }
+    }
+}
+
+#[pin_project]
+pub struct ResponseFuture<F, Converter> {
+    #[pin]
+    response_future: F,
+    converter: Converter,
+}
+impl<F, Filter, Response, NewResponse, Error> Future for ResponseFuture<F, Filter>
+where
+    F: Future<Output = Result<Response, Error>>,
+    Filter: Convert<Response, Output = NewResponse>,
+    Filter::Error: Into<Error>,
+{
+    type Output = Result<NewResponse, Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result_fut = this.response_future.poll(cx);
+        match result_fut {
+            Poll::Ready(result) => match result {
+                Ok(response) => {
+                    Poll::Ready(this.converter.try_convert(response).map_err(Into::into))
+                }
+                Err(err) => Poll::Ready(Err(err)),
+            },
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/canhttp/src/convert/response.rs
+++ b/canhttp/src/convert/response.rs
@@ -6,17 +6,24 @@ use std::task::{Context, Poll};
 use tower::Service;
 use tower_layer::Layer;
 
+/// Convert responses of a service into another type, where the conversion may fail.
+///
+/// This [`Layer`] produces instances of the [`ConvertResponse`] service.
+///
+/// [`Layer`]: tower::Layer
 #[derive(Debug, Clone)]
 pub struct ConvertResponseLayer<C> {
     converter: C,
 }
 
 impl<C> ConvertResponseLayer<C> {
+    /// Creates a new [`ConvertResponseLayer`]
     pub fn new(converter: C) -> Self {
         Self { converter }
     }
 }
 
+/// Convert the inner service response to another type, where the conversion may fail.
 #[derive(Debug, Clone)]
 pub struct ConvertResponse<S, C> {
     inner: S,

--- a/canhttp/src/filter_response/mod.rs
+++ b/canhttp/src/filter_response/mod.rs
@@ -1,0 +1,86 @@
+use pin_project::pin_project;
+use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::Service;
+use tower_layer::Layer;
+
+pub trait FilterResponse<Response> {
+    type Response;
+    type Error;
+
+    fn filter(&mut self, response: Response) -> Result<Self::Response, Self::Error>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FilterResponseLayer<F> {
+    filter: F,
+}
+
+#[derive(Debug, Clone)]
+pub struct FilterResponseService<S, F> {
+    inner: S,
+    filter: F,
+}
+
+impl<S, F: Clone> Layer<S> for FilterResponseLayer<F> {
+    type Service = FilterResponseService<S, F>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Self::Service {
+            inner,
+            filter: self.filter.clone(),
+        }
+    }
+}
+
+impl<S, Request, Response, NewResponse, F> Service<Request> for FilterResponseService<S, F>
+where
+    S: Service<Request, Response = Response>,
+    F: FilterResponse<Response, Response = NewResponse> + Clone,
+    F::Error: Into<S::Error>,
+{
+    type Response = NewResponse;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, F>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        ResponseFuture {
+            response_future: self.inner.call(req),
+            filter: self.filter.clone(),
+        }
+    }
+}
+
+#[pin_project]
+pub struct ResponseFuture<F, Filter> {
+    #[pin]
+    response_future: F,
+    filter: Filter,
+}
+
+impl<F, Filter, Response, NewResponse, Error> Future for ResponseFuture<F, Filter>
+where
+    F: Future<Output = Result<Response, Error>>,
+    Filter: FilterResponse<Response, Response = NewResponse>,
+    Filter::Error: Into<Error>,
+{
+    type Output = Result<NewResponse, Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result_fut = this.response_future.poll(cx);
+        match result_fut {
+            Poll::Ready(result) => match result {
+                Ok(response) => Poll::Ready(this.filter.filter(response).map_err(Into::into)),
+                Err(err) => Poll::Ready(Err(err)),
+            },
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/canhttp/src/filter_response/mod.rs
+++ b/canhttp/src/filter_response/mod.rs
@@ -3,8 +3,8 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tower::Service;
-use tower_layer::Layer;
+use tower::{Service, ServiceBuilder};
+use tower_layer::{Layer, Stack};
 
 pub trait FilterResponse<Response> {
     type Response;
@@ -82,5 +82,15 @@ where
             },
             Poll::Pending => Poll::Pending,
         }
+    }
+}
+
+pub trait FilterResponseServiceBuilder<L> {
+    fn filter_response<F>(self, f: F) -> ServiceBuilder<Stack<FilterResponseLayer<F>, L>>;
+}
+
+impl<L> FilterResponseServiceBuilder<L> for ServiceBuilder<L> {
+    fn filter_response<F>(self, f: F) -> ServiceBuilder<Stack<FilterResponseLayer<F>, L>> {
+        self.layer(FilterResponseLayer { filter: f })
     }
 }

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -1,3 +1,5 @@
 pub use request::{HttpJsonRpcRequest, JsonRequestConversionLayer, JsonRpcRequestBody};
+pub use response::{JsonResponseConversionLayer, HttpJsonRpcResponse, JsonRpcResult};
 
 mod request;
+mod response;

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -70,6 +70,7 @@ mod response;
 /// See the [module docs](crate::http::json) for an example.
 ///
 /// [`Service`]: tower::Service
+#[derive(Debug)]
 pub struct JsonConversionLayer<I, O> {
     _marker: PhantomData<(I, O)>,
 }
@@ -80,6 +81,20 @@ impl<I, O> JsonConversionLayer<I, O> {
         Self {
             _marker: PhantomData,
         }
+    }
+}
+
+impl<I, O> Clone for JsonConversionLayer<I, O> {
+    fn clone(&self) -> Self {
+        Self {
+            _marker: self._marker,
+        }
+    }
+}
+
+impl<I, O> Default for JsonConversionLayer<I, O> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -1,4 +1,4 @@
-pub use request::{HttpJsonRpcRequest, JsonRequestConversionLayer, JsonRpcRequestBody};
+pub use request::{HttpJsonRpcRequest, JsonRequestConverter, JsonRpcRequestBody};
 pub use response::{
     HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConversionLayer, JsonRpcResult,
 };

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -1,5 +1,5 @@
 pub use request::{HttpJsonRpcRequest, JsonRequestConversionLayer, JsonRpcRequestBody};
-pub use response::{JsonResponseConversionLayer, HttpJsonRpcResponse, JsonRpcResult};
+pub use response::{JsonResponseConversionLayer, HttpJsonRpcResponse, JsonRpcResult, JsonResponseConversionError};
 
 mod request;
 mod response;

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -61,6 +61,9 @@ use serde::Serialize;
 use std::marker::PhantomData;
 use tower_layer::Layer;
 
+#[cfg(test)]
+mod tests;
+
 mod request;
 mod response;
 

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -1,1 +1,3 @@
+pub use request::{HttpJsonRpcRequest, JsonRequestConversionLayer, JsonRpcRequestBody};
+
 mod request;

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -1,9 +1,101 @@
+//! Middleware to add a JSON translation layer (over HTTP).
+//!
+//! Transforms a low-level service that transmits bytes into one that transmits JSON payloads:
+//!
+//! ```text
+//!                 │                     ▲              
+//! http::Request<I>│                     │http::Response<O>
+//!               ┌─┴─────────────────────┴───┐          
+//!               │   JsonResponseConverter   │          
+//!               └─┬─────────────────────▲───┘          
+//!                 │                     │              
+//!               ┌─▼─────────────────────┴───┐          
+//!               │   JsonRequestConverter    │          
+//!               └─┬─────────────────────┬───┘          
+//!      HttpRequest│                     │HttpResponse
+//!                 ▼                     │              
+//!               ┌─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─┐
+//!               │          SERVICE          │
+//!               └─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─┘
+//! ```
+//! This can be used to transmit any kind of JSON payloads, such as JSON RPC over HTTP.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use canhttp::http::{HttpRequest, HttpResponse, json::JsonConversionLayer};
+//! use ic_cdk::api::management_canister::http_request::{CanisterHttpRequestArgument as IcHttpRequest, HttpResponse as IcHttpResponse};
+//! use tower::{Service, ServiceBuilder, ServiceExt, BoxError};
+//! use serde_json::json;
+//!
+//! async fn echo_bytes(request: HttpRequest) -> Result<HttpResponse, BoxError> {
+//!     Ok(http::Response::new(request.into_body()))
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut service = ServiceBuilder::new()
+//!   .layer(JsonConversionLayer::<serde_json::Value, serde_json::Value>::new())
+//!   .service_fn(echo_bytes);
+//!
+//! let request = http::Request::post("https://internetcomputer.org")
+//!   .header("Content-Type", "application/json")
+//!   .body(json!({"key": "value"}))
+//!   .unwrap();
+//!
+//! let response = service.ready().await.unwrap().call(request).await.unwrap();
+//!
+//! assert_eq!(response.into_body()["key"], "value");
+//! # Ok(())
+//! # }
+
+use crate::convert::{ConvertRequest, ConvertRequestLayer, ConvertResponse, ConvertResponseLayer};
 pub use request::{
     HttpJsonRpcRequest, JsonRequestConversionError, JsonRequestConverter, JsonRpcRequestBody,
 };
 pub use response::{
     HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConverter, JsonRpcResult,
 };
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::marker::PhantomData;
+use tower_layer::Layer;
 
 mod request;
 mod response;
+
+/// Middleware that combines [`JsonRequestConverter`] to convert requests
+/// and [`JsonResponseConverter`] to convert responses to a [`Service`].
+///
+/// See the [module docs](crate::http::json) for an example.
+///
+/// [`Service`]: tower::Service
+pub struct JsonConversionLayer<I, O> {
+    _marker: PhantomData<(I, O)>,
+}
+
+impl<I, O> JsonConversionLayer<I, O> {
+    /// Returns a new [`JsonConversionLayer`].
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, I, O> Layer<S> for JsonConversionLayer<I, O>
+where
+    I: Serialize,
+    O: DeserializeOwned,
+{
+    type Service =
+        ConvertResponse<ConvertRequest<S, JsonRequestConverter<I>>, JsonResponseConverter<O>>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        let stack = tower_layer::Stack::new(
+            ConvertRequestLayer::new(JsonRequestConverter::<I>::new()),
+            ConvertResponseLayer::new(JsonResponseConverter::<O>::new()),
+        );
+        stack.layer(inner)
+    }
+}

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -1,5 +1,7 @@
 pub use request::{HttpJsonRpcRequest, JsonRequestConversionLayer, JsonRpcRequestBody};
-pub use response::{JsonResponseConversionLayer, HttpJsonRpcResponse, JsonRpcResult, JsonResponseConversionError};
+pub use response::{
+    HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConversionLayer, JsonRpcResult,
+};
 
 mod request;
 mod response;

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -1,0 +1,1 @@
+mod request;

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -1,6 +1,8 @@
-pub use request::{HttpJsonRpcRequest, JsonRequestConverter, JsonRpcRequestBody};
+pub use request::{
+    HttpJsonRpcRequest, JsonRequestConversionError, JsonRequestConverter, JsonRpcRequestBody,
+};
 pub use response::{
-    HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConversionLayer, JsonRpcResult,
+    HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConverter, JsonRpcResult,
 };
 
 mod request;

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -3,6 +3,7 @@ use crate::http::HttpRequest;
 use http::header::CONTENT_TYPE;
 use http::HeaderValue;
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use thiserror::Error;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
@@ -32,10 +33,29 @@ fn add_content_type_header_if_missing(mut request: HttpRequest) -> HttpRequest {
     request
 }
 
-#[derive(Clone, Debug)]
-pub struct JsonRequestConverter;
+#[derive(Debug)]
+pub struct JsonRequestConverter<T> {
+    _marker: PhantomData<T>,
+}
 
-impl<T> Convert<http::Request<T>> for JsonRequestConverter
+impl<T> JsonRequestConverter<T> {
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+// #[derive(Clone)] would otherwise introduce a bound T: Clone, which is not needed.
+impl<T> Clone for JsonRequestConverter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            _marker: self._marker,
+        }
+    }
+}
+
+impl<T> Convert<http::Request<T>> for JsonRequestConverter<T>
 where
     T: Serialize,
 {

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -31,6 +31,12 @@ impl<T> Clone for JsonRequestConverter<T> {
     }
 }
 
+impl<T> Default for JsonRequestConverter<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Error return when converting requests with [`JsonRequestConverter`].
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum JsonRequestConversionError {

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -75,7 +75,7 @@ impl<T> JsonRpcRequestBody<T> {
         Self {
             jsonrpc: "2.0".to_string(),
             method: method.into(),
-            id: None,
+            id: Some(serde_json::Value::Number(0.into())),
             params: Some(params),
         }
     }
@@ -86,5 +86,9 @@ impl<T> JsonRpcRequestBody<T> {
 
     pub fn method(&self) -> &str {
         &self.method
+    }
+
+    pub fn id(&self) -> Option<&serde_json::Value> {
+        self.id.as_ref()
     }
 }

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -59,11 +59,32 @@ impl<S> Layer<S> for JsonRequestConversionLayer {
     }
 }
 
-/// An envelope for all JSON-RPC requests.
+pub type HttpJsonRpcRequest<T> = http::Request<JsonRpcRequestBody<T>>;
+
+/// Body for all JSON-RPC requests, see the [specification](https://www.jsonrpc.org/specification).
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JsonRpcRequest<T> {
-    pub jsonrpc: String,
-    pub method: String,
-    pub id: u64,
-    pub params: T,
+pub struct JsonRpcRequestBody<T> {
+    jsonrpc: String,
+    method: String,
+    id: Option<serde_json::Value>,
+    params: Option<T>,
+}
+
+impl<T> JsonRpcRequestBody<T> {
+    pub fn new(method: impl Into<String>, params: T) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            method: method.into(),
+            id: None,
+            params: Some(params),
+        }
+    }
+
+    pub fn set_id(&mut self, id: u64) {
+        self.id = Some(serde_json::Value::Number(id.into()));
+    }
+
+    pub fn method(&self) -> &str {
+        &self.method
+    }
 }

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -1,14 +1,9 @@
 use crate::convert::Convert;
 use crate::http::HttpRequest;
 use http::header::CONTENT_TYPE;
-use http::{HeaderValue, Request};
+use http::HeaderValue;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tower::filter::Predicate;
-use tower::BoxError;
-use tower_layer::Layer;
-
-pub struct JsonRequestFilter;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum JsonRequestConversionError {
@@ -37,6 +32,7 @@ fn add_content_type_header_if_missing(mut request: HttpRequest) -> HttpRequest {
     request
 }
 
+#[derive(Clone, Debug)]
 pub struct JsonRequestConverter;
 
 impl<T> Convert<http::Request<T>> for JsonRequestConverter

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -1,7 +1,7 @@
 use crate::http::HttpRequest;
 use http::header::CONTENT_TYPE;
 use http::HeaderValue;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tower::filter::Predicate;
 use tower::BoxError;
@@ -57,4 +57,13 @@ impl<S> Layer<S> for JsonRequestConversionLayer {
     fn layer(&self, inner: S) -> Self::Service {
         tower::filter::Filter::new(inner, JsonRequestFilter)
     }
+}
+
+/// An envelope for all JSON-RPC requests.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonRpcRequest<T> {
+    pub jsonrpc: String,
+    pub method: String,
+    pub id: u64,
+    pub params: T,
 }

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -1,0 +1,140 @@
+use crate::http::HttpResponse;
+use pin_project::pin_project;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use thiserror::Error;
+use tower::{BoxError, Service};
+use tower_layer::Layer;
+
+pub type HttpJsonRpcResponse<T> = http::Response<JsonRpcResponseBody<T>>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonRpcResponseBody<T> {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    #[serde(flatten)]
+    pub result: JsonRpcResult<T>,
+}
+
+/// An envelope for all JSON-RPC replies.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JsonRpcResult<T> {
+    #[serde(rename = "result")]
+    Result(T),
+    #[serde(rename = "error")]
+    Error { code: i64, message: String },
+}
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum JsonResponseConversionError {
+    /// Response body could not be deserialized into a JSON-RPC response.
+    #[error("Invalid HTTP JSON-RPC response: status {status}, body: {body}, parsing error: {parsing_error:?}"
+    )]
+    InvalidJsonResponse {
+        status: u16,
+        body: String,
+        parsing_error: String,
+    },
+}
+
+fn try_deserialize_response<T>(
+    response: HttpResponse,
+) -> Result<http::Response<T>, JsonResponseConversionError>
+where
+    T: DeserializeOwned,
+{
+    let (parts, body) = response.into_parts();
+    let json_body: T = serde_json::from_slice(&body).map_err(|e| {
+        JsonResponseConversionError::InvalidJsonResponse {
+            status: parts.status.as_u16(),
+            body: String::from_utf8_lossy(&body).to_string(),
+            parsing_error: e.to_string(),
+        }
+    })?;
+    Ok(http::Response::from_parts(parts, json_body))
+}
+
+pub struct JsonResponseConversionLayer<T> {
+    _marker: PhantomData<T>,
+}
+
+impl<T> JsonResponseConversionLayer<T> {
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub struct JsonResponseConversion<S, T> {
+    inner: S,
+    _marker: PhantomData<T>,
+}
+
+impl<S, T> Layer<S> for JsonResponseConversionLayer<T> {
+    type Service = JsonResponseConversion<S, T>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Self::Service {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, T, Request, Error> Service<Request> for JsonResponseConversion<S, T>
+where
+    S: Service<Request, Response = HttpResponse, Error = Error>,
+    Error: Into<BoxError>,
+    T: DeserializeOwned,
+{
+    type Response = http::Response<T>;
+    type Error = BoxError;
+    type Future = ResponseFuture<S::Future, T>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request) -> ResponseFuture<S::Future, T> {
+        ResponseFuture {
+            response_future: self.inner.call(req),
+            _phantom_data: PhantomData::<T>,
+        }
+    }
+}
+
+#[pin_project]
+pub struct ResponseFuture<F, T> {
+    #[pin]
+    response_future: F,
+    _phantom_data: PhantomData<T>,
+}
+
+impl<F, E, T> Future for ResponseFuture<F, T>
+where
+    F: Future<Output = Result<HttpResponse, E>>,
+    E: Into<BoxError>,
+    T: DeserializeOwned,
+{
+    type Output = Result<http::Response<T>, BoxError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result_fut = this.response_future.poll(cx);
+
+        match result_fut {
+            Poll::Ready(result) => match result {
+                Ok(response) => {
+                    Poll::Ready(try_deserialize_response::<T>(response).map_err(Into::into))
+                }
+                Err(e) => Poll::Ready(Err(e.into())),
+            },
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -58,6 +58,7 @@ where
     Ok(http::Response::from_parts(parts, json_body))
 }
 
+// TODO XC-287: refactor to have a generic Response Filter mechanism
 pub struct JsonResponseConversionLayer<T> {
     _marker: PhantomData<T>,
 }

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -53,7 +53,7 @@ impl<T> JsonResponseConverter<T> {
 impl<T> Clone for JsonResponseConverter<T> {
     fn clone(&self) -> Self {
         Self {
-            _marker: self._marker.clone(),
+            _marker: self._marker,
         }
     }
 }

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -1,15 +1,9 @@
 use crate::convert::Convert;
 use crate::http::HttpResponse;
-use pin_project::pin_project;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::future::Future;
 use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use thiserror::Error;
-use tower::{BoxError, Service};
-use tower_layer::Layer;
 
 pub type HttpJsonRpcResponse<T> = http::Response<JsonRpcResponseBody<T>>;
 
@@ -42,9 +36,26 @@ pub enum JsonResponseConversionError {
     },
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct JsonResponseConverter<T> {
     _marker: PhantomData<T>,
+}
+
+impl<T> JsonResponseConverter<T> {
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+// #[derive(Clone)] would otherwise introduce a bound T: Clone, which is not needed.
+impl<T> Clone for JsonResponseConverter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            _marker: self._marker.clone(),
+        }
+    }
 }
 
 impl<T> Convert<HttpResponse> for JsonResponseConverter<T>

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 /// Convert responses of type [HttpResponse] into [`http::Response<T>`],
 /// where `T` can be deserialized.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct JsonResponseConverter<T> {
     _marker: PhantomData<T>,
 }
@@ -27,6 +27,12 @@ impl<T> Clone for JsonResponseConverter<T> {
         Self {
             _marker: self._marker,
         }
+    }
+}
+
+impl<T> Default for JsonResponseConverter<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -59,6 +59,7 @@ where
 }
 
 // TODO XC-287: refactor to have a generic Response Filter mechanism
+#[derive(Default)]
 pub struct JsonResponseConversionLayer<T> {
     _marker: PhantomData<T>,
 }

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -1,0 +1,122 @@
+use crate::http::json::{JsonConversionLayer, JsonRequestConverter, JsonResponseConverter};
+use crate::http::{HttpRequest, HttpResponse};
+use crate::ConvertServiceBuilder;
+use http::HeaderValue;
+use serde_json::json;
+use tower::{BoxError, Service, ServiceBuilder, ServiceExt};
+
+#[tokio::test]
+async fn should_convert_json_request() {
+    let url = "https://internetcomputer.org/";
+    let mut service = ServiceBuilder::new()
+        .convert_request(JsonRequestConverter::<serde_json::Value>::new())
+        .service_fn(echo_request);
+
+    let body = json!({"foo": "bar"});
+    let request = http::Request::post(url).body(body.clone()).unwrap();
+
+    let converted_request = service.ready().await.unwrap().call(request).await.unwrap();
+
+    assert_eq!(
+        serde_json::to_vec(&body).unwrap(),
+        converted_request.into_body()
+    );
+}
+
+#[tokio::test]
+async fn should_add_content_type_header_if_missing() {
+    let url = "https://internetcomputer.org/";
+    let mut service = ServiceBuilder::new()
+        .convert_request(JsonRequestConverter::<serde_json::Value>::new())
+        .service_fn(echo_request);
+
+    for (request_content_type, expected_content_type) in [
+        (None, "application/json"),
+        (Some("wrong-value"), "wrong-value"), //do not overwrite explicitly set header
+        (Some("application/json"), "application/json"),
+    ] {
+        let mut builder = http::Request::post(url);
+        if let Some(request_content_type) = request_content_type {
+            builder = builder.header(http::header::CONTENT_TYPE, request_content_type);
+        }
+        let request = builder
+            .header("other-header", "should-remain")
+            .body(json!({"foo": "bar"}))
+            .unwrap();
+
+        let converted_request = service
+            .ready()
+            .await
+            .unwrap()
+            .call(request.clone())
+            .await
+            .unwrap();
+
+        let (mut request_parts, _body) = request.into_parts();
+        let (mut converted_request_parts, _body) = converted_request.into_parts();
+
+        assert_eq!(request_parts.method, converted_request_parts.method);
+        assert_eq!(request_parts.uri, converted_request_parts.uri);
+        assert_eq!(request_parts.version, converted_request_parts.version);
+
+        // Headers should be identical, excepted for content-type
+        request_parts.headers.remove(http::header::CONTENT_TYPE);
+        let converted_request_content_type = converted_request_parts
+            .headers
+            .remove(http::header::CONTENT_TYPE)
+            .unwrap();
+        assert_eq!(
+            converted_request_content_type,
+            HeaderValue::from_static(expected_content_type)
+        );
+
+        assert_eq!(request_parts.headers, converted_request_parts.headers);
+    }
+}
+
+#[tokio::test]
+async fn should_convert_json_response() {
+    let mut service = ServiceBuilder::new()
+        .convert_response(JsonResponseConverter::<serde_json::Value>::new())
+        .service_fn(echo_response);
+
+    let expected_response = json!({"foo": "bar"});
+    let response = http::Response::new(serde_json::to_vec(&expected_response).unwrap());
+
+    let converted_response = service.ready().await.unwrap().call(response).await.unwrap();
+
+    assert_eq!(converted_response.into_body(), expected_response);
+}
+
+#[tokio::test]
+async fn should_convert_both_request_and_response() {
+    let mut service = ServiceBuilder::new()
+        .layer(JsonConversionLayer::<serde_json::Value, serde_json::Value>::new())
+        .service_fn(forward_body);
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call(
+            http::Request::post("https://internetcomputer.org/")
+                .body(json!({"foo": "bar"}))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.into_body(), json!({"foo": "bar"}));
+}
+
+async fn echo_request(request: HttpRequest) -> Result<HttpRequest, BoxError> {
+    Ok(request)
+}
+
+async fn echo_response(response: HttpResponse) -> Result<HttpResponse, BoxError> {
+    Ok(response)
+}
+
+async fn forward_body(request: HttpRequest) -> Result<HttpResponse, BoxError> {
+    Ok(http::Response::new(request.into_body()))
+}

--- a/canhttp/src/http/mod.rs
+++ b/canhttp/src/http/mod.rs
@@ -71,6 +71,8 @@ pub use request::{
 };
 pub use response::{HttpResponse, HttpResponseConversionLayer};
 
+#[cfg(feature = "json")]
+pub mod json;
 mod request;
 mod response;
 

--- a/canhttp/src/http/mod.rs
+++ b/canhttp/src/http/mod.rs
@@ -7,11 +7,11 @@
 //!              │                     ▲              
 //! http::Request│                     │http::Response
 //!            ┌─┴─────────────────────┴───┐          
-//!            │HttpResponseConversionLayer│          
+//!            │   HttpResponseConverter   │
 //!            └─┬─────────────────────▲───┘          
 //!              │                     │              
 //!            ┌─▼─────────────────────┴───┐          
-//!            │HttpRequestConversionLayer │          
+//!            │    HttpRequestConverter   │          
 //!            └─┬─────────────────────┬───┘          
 //! IcHttpRequest│                     │IcHttpResponse
 //!              ▼                     │              

--- a/canhttp/src/http/mod.rs
+++ b/canhttp/src/http/mod.rs
@@ -69,7 +69,10 @@ pub use request::{
     HttpRequest, HttpRequestConversionError, HttpRequestConverter,
     MaxResponseBytesRequestExtension, TransformContextRequestExtension,
 };
-pub use response::{HttpResponse, HttpResponseConversionError, HttpResponseConverter};
+pub use response::{
+    FilterNonSuccessfulHttpResponse, FilterNonSuccessulHttpResponseError, HttpResponse,
+    HttpResponseConversionError, HttpResponseConverter,
+};
 
 #[cfg(feature = "json")]
 pub mod json;

--- a/canhttp/src/http/mod.rs
+++ b/canhttp/src/http/mod.rs
@@ -69,7 +69,9 @@ pub use request::{
     HttpRequest, HttpRequestConversionLayer, MaxResponseBytesRequestExtension,
     TransformContextRequestExtension,
 };
-pub use response::{HttpResponse, HttpResponseConversionLayer};
+pub use response::{
+    ConvertHttpResponse, HttpResponse, HttpResponseConversionError, HttpResponseConversionLayer,
+};
 
 #[cfg(feature = "json")]
 pub mod json;

--- a/canhttp/src/http/mod.rs
+++ b/canhttp/src/http/mod.rs
@@ -85,8 +85,8 @@ use crate::{
 };
 use tower::Layer;
 
-/// Middleware that combines [`HttpRequestConversionLayer`] to convert requests
-/// and [`HttpResponseConversionLayer`] to convert responses to a [`Service`].
+/// Middleware that combines [`HttpRequestConverter`] to convert requests
+/// and [`HttpResponseConverter`] to convert responses to a [`Service`].
 ///
 /// See the [module docs](crate::http) for an example.
 ///

--- a/canhttp/src/http/mod.rs
+++ b/canhttp/src/http/mod.rs
@@ -79,10 +79,7 @@ pub mod json;
 mod request;
 mod response;
 
-use crate::{
-    convert::{ConvertRequest, ConvertResponse},
-    ConvertRequestLayer, ConvertResponseLayer,
-};
+use crate::convert::{ConvertRequest, ConvertRequestLayer, ConvertResponse, ConvertResponseLayer};
 use tower::Layer;
 
 /// Middleware that combines [`HttpRequestConverter`] to convert requests

--- a/canhttp/src/http/request.rs
+++ b/canhttp/src/http/request.rs
@@ -104,14 +104,23 @@ impl TransformContextRequestExtension for http::request::Builder {
     }
 }
 
+/// Error return when converting requests with [`HttpRequestConverter`].
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum HttpRequestConversionError {
+    /// HTTP method is not supported
     #[error("HTTP method `{0}` is not supported")]
     UnsupportedHttpMethod(String),
+    /// Header name is invalid.
     #[error("HTTP header `{name}` has an invalid value: {reason}")]
-    InvalidHttpHeaderValue { name: String, reason: String },
+    InvalidHttpHeaderValue {
+        /// Header name
+        name: String,
+        /// Reason for header value being invalid.
+        reason: String,
+    },
 }
 
+/// Convert requests of type [`HttpRequest`] into [`IcHttpRequest`].
 #[derive(Clone, Debug)]
 pub struct HttpRequestConverter;
 

--- a/canhttp/src/http/request.rs
+++ b/canhttp/src/http/request.rs
@@ -1,11 +1,9 @@
+use crate::convert::Convert;
 use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument as IcHttpRequest, HttpHeader as IcHttpHeader,
     HttpMethod as IcHttpMethod, TransformContext,
 };
 use thiserror::Error;
-use tower::filter::Predicate;
-use tower::BoxError;
-use tower_layer::Layer;
 
 /// HTTP request with a body made of bytes.
 pub type HttpRequest = http::Request<Vec<u8>>;
@@ -114,67 +112,49 @@ pub enum HttpRequestConversionError {
     InvalidHttpHeaderValue { name: String, reason: String },
 }
 
-fn try_map_http_request(request: HttpRequest) -> Result<IcHttpRequest, HttpRequestConversionError> {
-    let url = request.uri().to_string();
-    let max_response_bytes = request.get_max_response_bytes();
-    let method = match request.method().as_str() {
-        "GET" => IcHttpMethod::GET,
-        "POST" => IcHttpMethod::POST,
-        "HEAD" => IcHttpMethod::HEAD,
-        unsupported => {
-            return Err(HttpRequestConversionError::UnsupportedHttpMethod(
-                unsupported.to_string(),
-            ))
-        }
-    };
-    let headers = request
-        .headers()
-        .iter()
-        .map(|(header_name, header_value)| match header_value.to_str() {
-            Ok(value) => Ok(IcHttpHeader {
-                name: header_name.to_string(),
-                value: value.to_string(),
-            }),
-            Err(e) => Err(HttpRequestConversionError::InvalidHttpHeaderValue {
-                name: header_name.to_string(),
-                reason: e.to_string(),
-            }),
+#[derive(Clone, Debug)]
+pub struct HttpRequestConverter;
+
+impl Convert<HttpRequest> for HttpRequestConverter {
+    type Output = IcHttpRequest;
+    type Error = HttpRequestConversionError;
+
+    fn try_convert(&mut self, request: HttpRequest) -> Result<Self::Output, Self::Error> {
+        let url = request.uri().to_string();
+        let max_response_bytes = request.get_max_response_bytes();
+        let method = match request.method().as_str() {
+            "GET" => IcHttpMethod::GET,
+            "POST" => IcHttpMethod::POST,
+            "HEAD" => IcHttpMethod::HEAD,
+            unsupported => {
+                return Err(HttpRequestConversionError::UnsupportedHttpMethod(
+                    unsupported.to_string(),
+                ))
+            }
+        };
+        let headers = request
+            .headers()
+            .iter()
+            .map(|(header_name, header_value)| match header_value.to_str() {
+                Ok(value) => Ok(IcHttpHeader {
+                    name: header_name.to_string(),
+                    value: value.to_string(),
+                }),
+                Err(e) => Err(HttpRequestConversionError::InvalidHttpHeaderValue {
+                    name: header_name.to_string(),
+                    reason: e.to_string(),
+                }),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let transform = request.get_transform_context().cloned();
+        let body = Some(request.into_body());
+        Ok(IcHttpRequest {
+            url,
+            max_response_bytes,
+            method,
+            headers,
+            body,
+            transform,
         })
-        .collect::<Result<Vec<_>, _>>()?;
-    let transform = request.get_transform_context().cloned();
-    let body = Some(request.into_body());
-    Ok(IcHttpRequest {
-        url,
-        max_response_bytes,
-        method,
-        headers,
-        body,
-        transform,
-    })
-}
-
-pub struct HttpRequestFilter;
-
-impl Predicate<HttpRequest> for HttpRequestFilter {
-    type Request = IcHttpRequest;
-
-    fn check(&mut self, request: HttpRequest) -> Result<Self::Request, BoxError> {
-        try_map_http_request(request).map_err(Into::into)
-    }
-}
-
-/// Middleware to convert a request of type [`HttpRequest`] into
-/// one of type [`IcHttpRequest`] to a [`Service`].
-///
-/// See the [module docs](crate::http) for an example.
-///
-/// [`Service`]: tower::Service
-pub struct HttpRequestConversionLayer;
-
-impl<S> Layer<S> for HttpRequestConversionLayer {
-    type Service = tower::filter::Filter<S, HttpRequestFilter>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        tower::filter::Filter::new(inner, HttpRequestFilter)
     }
 }

--- a/canhttp/src/http/response.rs
+++ b/canhttp/src/http/response.rs
@@ -6,17 +6,32 @@ use thiserror::Error;
 /// HTTP response with a body made of bytes.
 pub type HttpResponse = http::Response<Vec<u8>>;
 
+/// Error returned when converting respones with [`HttpResponseConverter`].
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 #[allow(clippy::enum_variant_names)] //current variants reflect invalid data and so start with the prefix Invalid.
 pub enum HttpResponseConversionError {
+    /// Status code is invalid
     #[error("Status code is invalid")]
     InvalidStatusCode,
+    /// Header name is invalid.
     #[error("HTTP header `{name}` is invalid: {reason}")]
-    InvalidHttpHeaderName { name: String, reason: String },
+    InvalidHttpHeaderName {
+        /// Header name
+        name: String,
+        /// Reason for being invalid.
+        reason: String,
+    },
+    /// Header value is invalid.
     #[error("HTTP header `{name}` has an invalid value: {reason}")]
-    InvalidHttpHeaderValue { name: String, reason: String },
+    InvalidHttpHeaderValue {
+        /// Header name
+        name: String,
+        /// Reason for header value being invalid.
+        reason: String,
+    },
 }
 
+/// Convert responses of type [`IcHttpResponse`] into [HttpResponse].
 #[derive(Debug, Clone)]
 pub struct HttpResponseConverter;
 
@@ -64,12 +79,15 @@ impl Convert<IcHttpResponse> for HttpResponseConverter {
     }
 }
 
+/// Error returned when converting responses with [`FilterNonSuccessfulHttpResponse`].
 #[derive(Error, Clone, Debug)]
 pub enum FilterNonSuccessulHttpResponseError<T> {
+    /// Response has a non-successful status code.
     #[error("HTTP response is not successful: {0:?}")]
     UnsuccessfulResponse(http::Response<T>),
 }
 
+/// Filter out non-successful responses.
 #[derive(Clone, Debug)]
 pub struct FilterNonSuccessfulHttpResponse;
 

--- a/canhttp/src/http/response.rs
+++ b/canhttp/src/http/response.rs
@@ -1,12 +1,6 @@
 use crate::convert::Convert;
 use ic_cdk::api::management_canister::http_request::HttpResponse as IcHttpResponse;
-use pin_project::pin_project;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use thiserror::Error;
-use tower::{BoxError, Service};
-use tower_layer::Layer;
 
 /// HTTP response with a body made of bytes.
 pub type HttpResponse = http::Response<Vec<u8>>;

--- a/canhttp/src/http/response.rs
+++ b/canhttp/src/http/response.rs
@@ -21,6 +21,18 @@ pub enum HttpResponseConversionError {
     InvalidHttpHeaderValue { name: String, reason: String },
 }
 
+#[derive(Debug, Clone)]
+pub struct FilterHttpResponse;
+
+impl FilterResponse<IcHttpResponse> for FilterHttpResponse {
+    type Response = HttpResponse;
+    type Error = HttpResponseConversionError;
+
+    fn filter(&mut self, response: IcHttpResponse) -> Result<Self::Response, Self::Error> {
+        try_map_http_response(response)
+    }
+}
+
 fn try_map_http_response(
     response: IcHttpResponse,
 ) -> Result<HttpResponse, HttpResponseConversionError> {

--- a/canhttp/src/http/response.rs
+++ b/canhttp/src/http/response.rs
@@ -1,3 +1,4 @@
+use crate::convert::Convert;
 use ic_cdk::api::management_canister::http_request::HttpResponse as IcHttpResponse;
 use pin_project::pin_project;
 use std::future::Future;
@@ -22,13 +23,13 @@ pub enum HttpResponseConversionError {
 }
 
 #[derive(Debug, Clone)]
-pub struct FilterHttpResponse;
+pub struct ConvertHttpResponse;
 
-impl FilterResponse<IcHttpResponse> for FilterHttpResponse {
-    type Response = HttpResponse;
+impl Convert<IcHttpResponse> for ConvertHttpResponse {
+    type Output = HttpResponse;
     type Error = HttpResponseConversionError;
 
-    fn filter(&mut self, response: IcHttpResponse) -> Result<Self::Response, Self::Error> {
+    fn try_convert(&mut self, response: IcHttpResponse) -> Result<Self::Output, Self::Error> {
         try_map_http_response(response)
     }
 }

--- a/canhttp/src/json/mod.rs
+++ b/canhttp/src/json/mod.rs
@@ -1,0 +1,60 @@
+use crate::http::HttpRequest;
+use http::header::CONTENT_TYPE;
+use http::HeaderValue;
+use serde::Serialize;
+use thiserror::Error;
+use tower::filter::Predicate;
+use tower::BoxError;
+use tower_layer::Layer;
+
+pub struct JsonRequestFilter;
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum JsonRequestConversionError {
+    #[error("Invalid JSON body: {0}")]
+    InvalidJson(String),
+}
+
+impl<T> Predicate<http::Request<T>> for JsonRequestFilter
+where
+    T: Serialize,
+{
+    type Request = HttpRequest;
+
+    fn check(&mut self, request: http::Request<T>) -> Result<Self::Request, BoxError> {
+        try_serialize_request(request)
+            .map(add_content_type_header_if_missing)
+            .map_err(Into::into)
+    }
+}
+
+fn try_serialize_request<T>(
+    request: http::Request<T>,
+) -> Result<HttpRequest, JsonRequestConversionError>
+where
+    T: Serialize,
+{
+    let (parts, body) = request.into_parts();
+    let json_body = serde_json::to_vec(&body)
+        .map_err(|e| JsonRequestConversionError::InvalidJson(e.to_string()))?;
+    Ok(HttpRequest::from_parts(parts, json_body))
+}
+
+fn add_content_type_header_if_missing(mut request: HttpRequest) -> HttpRequest {
+    if !request.headers().contains_key(CONTENT_TYPE) {
+        request
+            .headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    }
+    request
+}
+
+pub struct JsonRequestConversionLayer;
+
+impl<S> Layer<S> for JsonRequestConversionLayer {
+    type Service = tower::filter::Filter<S, JsonRequestFilter>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        tower::filter::Filter::new(inner, JsonRequestFilter)
+    }
+}

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -3,7 +3,7 @@
 //! leveraging the modularity of the [tower framework](https://rust-lang.guide/guide/learn-async-rust/tower.html).
 
 #![forbid(unsafe_code)]
-#![forbid(missing_docs)]
+// #![forbid(missing_docs)]
 
 pub use client::{Client, IcError};
 pub use cycles::{
@@ -14,4 +14,6 @@ mod client;
 mod cycles;
 #[cfg(feature = "http")]
 pub mod http;
+#[cfg(feature = "json")]
+pub mod json;
 pub mod observability;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -5,14 +5,15 @@
 #![forbid(unsafe_code)]
 // #![forbid(missing_docs)]
 
-pub use client::{Client, IcError};
+pub use client::{Client, IcError, IcHttpRequestWithCycles};
 pub use cycles::{
     CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, CyclesCostEstimator,
 };
+pub use convert::ConvertResponseServiceBuilder;
 
 mod client;
 mod cycles;
-mod filter_response;
+mod convert;
 #[cfg(feature = "http")]
 pub mod http;
 pub mod observability;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -14,6 +14,4 @@ mod client;
 mod cycles;
 #[cfg(feature = "http")]
 pub mod http;
-#[cfg(feature = "json")]
-pub mod json;
 pub mod observability;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -12,6 +12,7 @@ pub use cycles::{
 
 mod client;
 mod cycles;
+mod filter_response;
 #[cfg(feature = "http")]
 pub mod http;
 pub mod observability;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -9,7 +9,7 @@ pub use client::{Client, IcError, IcHttpRequestWithCycles};
 pub use cycles::{
     CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, CyclesCostEstimator,
 };
-pub use convert::ConvertResponseServiceBuilder;
+pub use convert::ConvertServiceBuilder;
 
 mod client;
 mod cycles;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -6,14 +6,14 @@
 // #![forbid(missing_docs)]
 
 pub use client::{Client, IcError, IcHttpRequestWithCycles};
+pub use convert::{ConvertRequestLayer, ConvertResponseLayer, ConvertServiceBuilder};
 pub use cycles::{
     CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, CyclesCostEstimator,
 };
-pub use convert::ConvertServiceBuilder;
 
 mod client;
-mod cycles;
 mod convert;
+mod cycles;
 #[cfg(feature = "http")]
 pub mod http;
 pub mod observability;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -3,6 +3,7 @@
 //! leveraging the modularity of the [tower framework](https://rust-lang.guide/guide/learn-async-rust/tower.html).
 
 #![forbid(unsafe_code)]
+// TODO XC-287: add docs
 // #![forbid(missing_docs)]
 
 pub use client::{Client, IcError, IcHttpRequestWithCycles};

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -7,13 +7,13 @@
 // #![forbid(missing_docs)]
 
 pub use client::{Client, IcError, IcHttpRequestWithCycles};
-pub use convert::{ConvertRequestLayer, ConvertResponseLayer, ConvertServiceBuilder};
+pub use convert::ConvertServiceBuilder;
 pub use cycles::{
     CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, CyclesCostEstimator,
 };
 
 mod client;
-mod convert;
+pub mod convert;
 mod cycles;
 #[cfg(feature = "http")]
 pub mod http;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -3,8 +3,7 @@
 //! leveraging the modularity of the [tower framework](https://rust-lang.guide/guide/learn-async-rust/tower.html).
 
 #![forbid(unsafe_code)]
-// TODO XC-287: add docs
-// #![forbid(missing_docs)]
+#![forbid(missing_docs)]
 
 pub use client::{Client, IcError, IcHttpRequestWithCycles};
 pub use convert::ConvertServiceBuilder;

--- a/e2e/rust/src/main.rs
+++ b/e2e/rust/src/main.rs
@@ -64,7 +64,7 @@ pub async fn test() {
             // Check response structure around gas price
             assert_eq!(
                 &response[..36],
-                "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":\"0x"
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0x"
             );
             assert_eq!(&response[response.len() - 2..], "\"}");
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -172,11 +172,11 @@ fn observe_response(method: MetricRpcMethod, host: MetricRpcHost, status: u16) {
     add_metric_entry!(responses, (method, host, status.into()), 1);
 }
 
-type JsonRpcServiceBuilder = ServiceBuilder<
+type JsonRpcServiceBuilder<I> = ServiceBuilder<
     Stack<
         ConvertRequestLayer<HttpRequestConverter>,
         Stack<
-            ConvertRequestLayer<JsonRequestConverter>,
+            ConvertRequestLayer<JsonRequestConverter<I>>,
             Stack<SetRequestHeaderLayer<HeaderValue>, Identity>,
         >,
     >,
@@ -185,13 +185,13 @@ type JsonRpcServiceBuilder = ServiceBuilder<
 /// Middleware that takes care of transforming the request.
 ///
 /// It's required to separate it from the other middlewares, to compute the exact request cost.
-pub fn service_request_builder() -> JsonRpcServiceBuilder {
+pub fn service_request_builder<I>() -> JsonRpcServiceBuilder<I> {
     ServiceBuilder::new()
         .insert_request_header_if_not_present(
             CONTENT_TYPE,
             HeaderValue::from_static(CONTENT_TYPE_VALUE),
         )
-        .convert_request(JsonRequestConverter)
+        .convert_request(JsonRequestConverter::<I>::new())
         .convert_request(HttpRequestConverter)
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -8,18 +8,20 @@ use crate::{
     types::{MetricRpcHost, MetricRpcMethod, ResolvedRpcService},
     util::canonicalize_json,
 };
-use canhttp::http::json::{
-    HttpJsonRpcRequest, HttpJsonRpcResponse, JsonRequestConversionError, JsonRequestConverter,
-    JsonResponseConversionError, JsonResponseConverter, JsonRpcRequestBody,
-};
-use canhttp::http::{
-    FilterNonSuccessfulHttpResponse, FilterNonSuccessulHttpResponseError,
-    HttpRequestConversionError, HttpRequestConverter, HttpResponseConversionError,
-    HttpResponseConverter, MaxResponseBytesRequestExtension, TransformContextRequestExtension,
-};
 use canhttp::{
-    observability::ObservabilityLayer, ConvertRequestLayer, ConvertServiceBuilder,
-    CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, IcError,
+    convert::ConvertRequestLayer,
+    http::{
+        json::{
+            HttpJsonRpcRequest, HttpJsonRpcResponse, JsonRequestConversionError,
+            JsonRequestConverter, JsonResponseConversionError, JsonResponseConverter,
+            JsonRpcRequestBody,
+        },
+        FilterNonSuccessfulHttpResponse, FilterNonSuccessulHttpResponseError,
+        HttpRequestConversionError, HttpRequestConverter, HttpResponseConversionError,
+        HttpResponseConverter, MaxResponseBytesRequestExtension, TransformContextRequestExtension,
+    },
+    observability::ObservabilityLayer,
+    ConvertServiceBuilder, CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, IcError,
 };
 use evm_rpc_types::{HttpOutcallError, ProviderError, RpcError, RpcResult, ValidationError};
 use http::header::CONTENT_TYPE;

--- a/src/http.rs
+++ b/src/http.rs
@@ -144,15 +144,17 @@ where
         .service(canhttp::Client)
 }
 
-/// Middleware that takes care of transforming the request.
-///
-/// It's required to separate it from the other middlewares, to compute the exact request cost.
-pub fn service_request_builder() -> ServiceBuilder<
+type JsonRpcServiceBuilder = ServiceBuilder<
     Stack<
         HttpRequestConversionLayer,
         Stack<JsonRequestConversionLayer, Stack<SetRequestHeaderLayer<HeaderValue>, Identity>>,
     >,
-> {
+>;
+
+/// Middleware that takes care of transforming the request.
+///
+/// It's required to separate it from the other middlewares, to compute the exact request cost.
+pub fn service_request_builder() -> JsonRpcServiceBuilder {
     ServiceBuilder::new()
         .insert_request_header_if_not_present(
             CONTENT_TYPE,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
 use candid::candid_method;
 use canhttp::{CyclesChargingPolicy, CyclesCostEstimator};
 use evm_rpc::candid_rpc::CandidRpcClient;
-use evm_rpc::http::{
-    get_http_response_body, service_request_builder, ChargingPolicyWithCollateral,
-};
+use evm_rpc::http::{service_request_builder, ChargingPolicyWithCollateral};
 use evm_rpc::logs::INFO;
 use evm_rpc::memory::{
     get_num_subnet_nodes, insert_api_key, is_api_key_principal, is_demo_active, remove_api_key,
@@ -19,7 +17,7 @@ use evm_rpc::{
     memory::UNSTABLE_METRICS,
     types::Metrics,
 };
-use evm_rpc_types::{Hex32, MultiRpcResult, RpcResult};
+use evm_rpc_types::{Hex32, HttpOutcallError, MultiRpcResult, RpcResult};
 use ic_canister_log::log;
 use ic_cdk::{
     api::{
@@ -152,7 +150,14 @@ async fn request(
         max_response_bytes,
     )
     .await?;
-    get_http_response_body(response)
+    serde_json::to_string(response.body()).map_err(|e| {
+        HttpOutcallError::InvalidHttpJsonRpcResponse {
+            status: response.status().as_u16(),
+            body: format!("{:?}", response.body()),
+            parsing_error: Some(format!("{e}")),
+        }
+        .into()
+    })
 }
 
 #[query(name = "requestCost")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,6 @@ use ic_cdk::{
     query, update,
 };
 use ic_metrics_encoder::MetricsEncoder;
-use std::convert::Infallible;
 use tower::Service;
 
 pub fn require_api_key_principal_or_controller() -> Result<(), String> {
@@ -178,7 +177,7 @@ async fn request_cost(
 
         async fn extract_request(
             request: IcHttpRequest,
-        ) -> Result<http::Response<IcHttpRequest>, Infallible> {
+        ) -> Result<http::Response<IcHttpRequest>, tower::BoxError> {
             Ok(http::Response::new(request))
         }
 

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -6,13 +6,13 @@ use crate::logs::{DEBUG, TRACE_HTTP};
 use crate::memory::{get_override_provider, next_request_id};
 use crate::providers::resolve_rpc_service;
 use crate::rpc_client::eth_rpc_error::{sanitize_send_raw_transaction_result, Parser};
-use crate::rpc_client::json::requests::JsonRpcRequest;
 use crate::rpc_client::json::responses::{
     Block, FeeHistory, JsonRpcReply, JsonRpcResult, LogEntry, TransactionReceipt,
 };
 use crate::rpc_client::numeric::{TransactionCount, Wei};
 use crate::types::MetricRpcMethod;
 use candid::candid_method;
+use canhttp::http::json::JsonRpcRequestBody;
 use canhttp::http::{MaxResponseBytesRequestExtension, TransformContextRequestExtension};
 use evm_rpc_types::{HttpOutcallError, RpcError, RpcService};
 use ic_canister_log::log;
@@ -171,20 +171,11 @@ pub async fn call<I, O>(
     mut response_size_estimate: ResponseSizeEstimate,
 ) -> Result<O, RpcError>
 where
-    I: Serialize + Debug,
+    I: Serialize + Clone + Debug,
     O: DeserializeOwned + HttpResponsePayload,
 {
     use tower::Service;
 
-    let eth_method = method.into();
-    let rpc_method = MetricRpcMethod(eth_method.clone());
-    let mut client = http_client(rpc_method);
-    let mut rpc_request = JsonRpcRequest {
-        jsonrpc: "2.0".to_string(),
-        params,
-        method: eth_method.clone(),
-        id: 1,
-    };
     let transform_op = O::response_transform()
         .as_ref()
         .map(|t| {
@@ -193,26 +184,31 @@ where
             buf
         })
         .unwrap_or_default();
-    let (parts, _body) = resolve_rpc_service(provider.clone())?
+
+    let request = resolve_rpc_service(provider.clone())?
         .post(&get_override_provider())?
         .transform_context(TransformContext::from_name(
             "cleanup_response".to_owned(),
             transform_op.clone(),
         ))
-        .body(())
-        .expect("BUG: invalid request")
-        .into_parts();
+        .body(JsonRpcRequestBody::new(method, params))
+        .expect("BUG: invalid request");
+
+    let eth_method = request.body().method().to_string();
+    let mut client = http_client(MetricRpcMethod(eth_method.clone()));
     let mut retries = 0;
     loop {
-        rpc_request.id = next_request_id();
         let effective_size_estimate = response_size_estimate.get();
-        let request =
-            http::Request::from_parts(parts.clone(), serde_json::to_vec(&rpc_request).unwrap())
-                .max_response_bytes(effective_size_estimate);
+        let request = {
+            let mut request = request.clone().max_response_bytes(effective_size_estimate);
+            let body = request.body_mut();
+            body.set_id(next_request_id());
+            request
+        };
         let url = request.uri().clone();
         log!(
             TRACE_HTTP,
-            "Calling url (retries={retries}): {}, with payload: {rpc_request:?}",
+            "Calling url (retries={retries}): {}, with payload: {request:?}",
             url
         );
 

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -228,21 +228,7 @@ where
             result => result?,
         };
 
-        let (response_parts, response_body) = response.into_parts();
-
-        // JSON-RPC responses over HTTP should have a 2xx status code,
-        // even if the contained JsonRpcResult is an error.
-        // If the server is not available, it will sometimes (wrongly) return HTML that will fail parsing as JSON.
-        if !response_parts.status.is_success() {
-            return Err(HttpOutcallError::InvalidHttpJsonRpcResponse {
-                status: response_parts.status.as_u16(),
-                body: format!("{:?}", response_body),
-                parsing_error: None,
-            }
-            .into());
-        }
-
-        return match response_body.result {
+        return match response.into_body().result {
             canhttp::http::json::JsonRpcResult::Result(r) => Ok(r),
             canhttp::http::json::JsonRpcResult::Error { code, message } => {
                 Err(JsonRpcError { code, message }.into())

--- a/src/rpc_client/json/requests.rs
+++ b/src/rpc_client/json/requests.rs
@@ -251,12 +251,3 @@ pub struct AccessListItem {
     #[serde(rename = "storageKeys")]
     pub storage_keys: Vec<StorageKey>,
 }
-
-/// An envelope for all JSON-RPC requests.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JsonRpcRequest<T> {
-    pub jsonrpc: String,
-    pub method: String,
-    pub id: u64,
-    pub params: T,
-}

--- a/src/rpc_client/json/responses.rs
+++ b/src/rpc_client/json/responses.rs
@@ -316,7 +316,6 @@ impl AsRef<[u8]> for Data {
     }
 }
 
-
 //TODO XC-287: remove this type to use the corresponding ones from canhttp
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonRpcReply<T> {

--- a/src/rpc_client/json/responses.rs
+++ b/src/rpc_client/json/responses.rs
@@ -316,6 +316,8 @@ impl AsRef<[u8]> for Data {
     }
 }
 
+
+//TODO XC-287: remove this type to use the corresponding ones from canhttp
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonRpcReply<T> {
     pub id: u64,

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -295,7 +295,7 @@ impl EthRpcClient {
     ) -> MultiCallResults<O>
     where
         I: Serialize + Clone + Debug,
-        O: DeserializeOwned + HttpResponsePayload,
+        O: Debug + DeserializeOwned + HttpResponsePayload,
     {
         let providers = self.providers();
         let results = {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1986,7 +1986,7 @@ fn upgrade_should_keep_demo() {
         setup
             .request_cost(
                 RpcService::EthMainnet(EthMainnetService::PublicNode),
-                r#"{"jsonrpc":"2.0","id":0,"result":"0x1"}"#,
+                r#"{"jsonrpc":"2.0","id":0,"method":"test"}"#,
                 1000
             )
             .unwrap(),
@@ -1997,7 +1997,7 @@ fn upgrade_should_keep_demo() {
         setup
             .request_cost(
                 RpcService::EthMainnet(EthMainnetService::PublicNode),
-                r#"{"jsonrpc":"2.0","id":0,"result":"0x1"}"#,
+                r#"{"jsonrpc":"2.0","id":0,"method":"test"}"#,
                 1000
             )
             .unwrap(),
@@ -2015,7 +2015,7 @@ fn upgrade_should_change_demo() {
         setup
             .request_cost(
                 RpcService::EthMainnet(EthMainnetService::PublicNode),
-                r#"{"jsonrpc":"2.0","id":0,"result":"0x1"}"#,
+                r#"{"jsonrpc":"2.0","id":0,"method":"test"}"#,
                 1000
             )
             .unwrap(),
@@ -2029,7 +2029,7 @@ fn upgrade_should_change_demo() {
         setup
             .request_cost(
                 RpcService::EthMainnet(EthMainnetService::PublicNode),
-                r#"{"jsonrpc":"2.0","id":0,"result":"0x1"}"#,
+                r#"{"jsonrpc":"2.0","id":0,"method":"test"}"#,
                 1000
             )
             .unwrap(),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -45,7 +45,7 @@ const MAX_TICKS: usize = 10;
 
 const MOCK_REQUEST_URL: &str = "https://cloudflare-eth.com";
 const MOCK_REQUEST_PAYLOAD: &str = r#"{"id":1,"jsonrpc":"2.0","method":"eth_gasPrice"}"#;
-const MOCK_REQUEST_RESPONSE: &str = r#"{"id":1,"jsonrpc":"2.0","result":"0x00112233"}"#;
+const MOCK_REQUEST_RESPONSE: &str = r#"{"jsonrpc":"2.0","id":1,"result":"0x00112233"}"#;
 const MOCK_REQUEST_RESPONSE_BYTES: u64 = 1000;
 const MOCK_API_KEY: &str = "mock-api-key";
 
@@ -1150,7 +1150,8 @@ fn candid_rpc_should_err_when_service_unavailable() {
             HttpOutcallError::InvalidHttpJsonRpcResponse {
                 status: 503,
                 body: "Service unavailable".to_string(),
-                parsing_error: None,
+                //TODO XC-287: ideally we should not try to deserialize when status code not successful
+                parsing_error: Some("expected value at line 1 column 1".to_string())
             }
         ))
     );
@@ -1680,7 +1681,8 @@ fn candid_rpc_should_recognize_rate_limit() {
             HttpOutcallError::InvalidHttpJsonRpcResponse {
                 status: 429,
                 body: "(Rate limit error message)".to_string(),
-                parsing_error: None
+                //TODO XC-287: ideally we should not try to deserialize when status code not successful
+                parsing_error: Some("expected value at line 1 column 1".to_string())
             }
         ))
     );

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1150,8 +1150,7 @@ fn candid_rpc_should_err_when_service_unavailable() {
             HttpOutcallError::InvalidHttpJsonRpcResponse {
                 status: 503,
                 body: "Service unavailable".to_string(),
-                //TODO XC-287: ideally we should not try to deserialize when status code not successful
-                parsing_error: Some("expected value at line 1 column 1".to_string())
+                parsing_error: None
             }
         ))
     );
@@ -1681,8 +1680,7 @@ fn candid_rpc_should_recognize_rate_limit() {
             HttpOutcallError::InvalidHttpJsonRpcResponse {
                 status: 429,
                 body: "(Rate limit error message)".to_string(),
-                //TODO XC-287: ideally we should not try to deserialize when status code not successful
-                parsing_error: Some("expected value at line 1 column 1".to_string())
+                parsing_error: None
             }
         ))
     );


### PR DESCRIPTION
Follow-up on #370,  #364, and #374 to add a conversion layer between request and responses to handle [JSON RPC](https://www.jsonrpc.org/specification) over HTTP. 

Concretely:
1. Refactor existing infrastructure to handle errors explicitly, instead of having to downcast `BoxError`. This is beneficial since errors may happen at different layers and they all need to be handled by the above observability layer, e.g., add the corresponding metric in case the response has a non successful status.
2. Refactor existing infrastructure to transform request and response to use a single `Convert` trait to convert one type into another with some potential error.
3. Add a layer for `http::Request` and `http::Response` to transform their body into a JSON RPC type. This uses the above `Convert` trait. This conversion layer is behind a feature flag (`json`) since it requires `serde_json` to handle the serialization/deserialization
4. Add a new layer to filter out non-successful HTTP responses.