### PR TITLE
ci: fix reproducible build

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -22,6 +22,9 @@ echo "using rust version '$rust_version'"
 # here we set the toolchain to 'none' and rustup will pick up on ./rust-toolchain.toml
 run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
 
+echo "Install active Rust toolchain"
+rustup show active-toolchain || rustup toolchain install
+
 echo "looking for ic-wasm 0.3.5"
 if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.3.5" ]]
 then


### PR DESCRIPTION
The script `bootstrap` downloads the latest version of `rustup` to install the Rust toolchain, but its behavior changed with the latest version ([1.28.0](https://github.com/rust-lang/rustup/blob/5f3b27203d7ba5aaa27e3c53c3fdb611d98421bd/CHANGELOG.md)) so that the active Rust toolchain needs to be explicitly installed.