### PR TITLE
feat: retry layer

### DIFF
--- a/canhttp/src/client/mod.rs
+++ b/canhttp/src/client/mod.rs
@@ -1,3 +1,4 @@
+use crate::HttpsOutcallError;
 use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument as IcHttpRequest, HttpResponse as IcHttpResponse,
@@ -45,12 +46,8 @@ pub struct IcError {
     pub message: String,
 }
 
-impl IcError {
-    /// Determines whether the error indicates that the response was larger than the specified
-    /// [`max_response_bytes`](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-http_request) specified in the request.
-    ///
-    /// If true, retrying with a larger value for `max_response_bytes` may help.
-    pub fn is_response_too_large(&self) -> bool {
+impl HttpsOutcallError for IcError {
+    fn is_response_too_large(&self) -> bool {
         self.code == RejectionCode::SysFatal
             && (self.message.contains("size limit") || self.message.contains("length limit"))
     }

--- a/canhttp/src/client/mod.rs
+++ b/canhttp/src/client/mod.rs
@@ -1,4 +1,8 @@
-use crate::HttpsOutcallError;
+#[cfg(test)]
+mod tests;
+
+use crate::convert::ConvertError;
+use crate::{ConvertServiceBuilder, HttpsOutcallError};
 use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument as IcHttpRequest, HttpResponse as IcHttpResponse,
@@ -22,10 +26,9 @@ pub struct Client;
 
 impl Client {
     /// Create a new client returning custom errors.
-    pub fn new_with_error<CustomError: From<IcError>>(
-    ) -> impl Service<IcHttpRequestWithCycles, Response = IcHttpResponse, Error = CustomError> {
+    pub fn new_with_error<CustomError: From<IcError>>() -> ConvertError<Client, CustomError> {
         ServiceBuilder::new()
-            .map_err(CustomError::from)
+            .convert_error::<CustomError>()
             .service(Client)
     }
 

--- a/canhttp/src/client/mod.rs
+++ b/canhttp/src/client/mod.rs
@@ -33,8 +33,7 @@ impl Client {
     }
 
     /// Creates a new client where error type is erased.
-    pub fn new_with_box_error(
-    ) -> impl Service<IcHttpRequestWithCycles, Response = IcHttpResponse, Error = BoxError> {
+    pub fn new_with_box_error() -> ConvertError<Client, BoxError> {
         Self::new_with_error::<BoxError>()
     }
 }

--- a/canhttp/src/client/tests.rs
+++ b/canhttp/src/client/tests.rs
@@ -1,0 +1,7 @@
+use crate::Client;
+
+#[test]
+fn should_be_clone() {
+    let client = Client::new_with_box_error();
+    let _ = client.clone();
+}

--- a/canhttp/src/client/tests.rs
+++ b/canhttp/src/client/tests.rs
@@ -1,7 +1,43 @@
-use crate::Client;
+use crate::retry::DoubleMaxResponseBytes;
+use crate::{Client, HttpsOutcallError, IcError};
+use tower::{ServiceBuilder, ServiceExt};
 
+// Some middlewares like tower::retry need the underlying service to be cloneable.
 #[test]
 fn should_be_clone() {
     let client = Client::new_with_box_error();
     let _ = client.clone();
+
+    let client = Client::new_with_error::<CustomError>();
+    let _ = client.clone();
+}
+
+// Note that calling `Client::call` would require a canister environment.
+// We just ensure that the trait bounds are satisfied to have a service.
+#[tokio::test]
+async fn should_be_able_to_use_retry_layer() {
+    let mut service = ServiceBuilder::new()
+        .retry(DoubleMaxResponseBytes)
+        .service(Client::new_with_error::<CustomError>());
+    let _ = service.ready().await.unwrap();
+
+    let mut service = ServiceBuilder::new()
+        .retry(DoubleMaxResponseBytes)
+        .service(Client::new_with_box_error());
+    let _ = service.ready().await.unwrap();
+}
+
+#[derive(Debug)]
+struct CustomError(IcError);
+
+impl HttpsOutcallError for CustomError {
+    fn is_response_too_large(&self) -> bool {
+        self.0.is_response_too_large()
+    }
+}
+
+impl From<IcError> for CustomError {
+    fn from(value: IcError) -> Self {
+        CustomError(value)
+    }
 }

--- a/canhttp/src/convert/error.rs
+++ b/canhttp/src/convert/error.rs
@@ -1,0 +1,102 @@
+use pin_project::pin_project;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::Service;
+use tower_layer::Layer;
+
+#[derive(Debug)]
+pub struct ConvertErrorLayer<E> {
+    _marker: PhantomData<E>,
+}
+
+impl<L> ConvertErrorLayer<L> {
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<E> Clone for ConvertErrorLayer<E> {
+    fn clone(&self) -> Self {
+        Self {
+            _marker: self._marker,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ConvertError<S, E> {
+    inner: S,
+    _marker: PhantomData<E>,
+}
+
+impl<S: Clone, E> Clone for ConvertError<S, E> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _marker: self._marker,
+        }
+    }
+}
+
+impl<S, E> Layer<S> for ConvertErrorLayer<E> {
+    type Service = ConvertError<S, E>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Self::Service {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, Request, Error, NewError> Service<Request> for ConvertError<S, NewError>
+where
+    S: Service<Request, Error = Error>,
+    Error: Into<NewError>,
+{
+    type Response = S::Response;
+    type Error = NewError;
+    type Future = ResponseFuture<S::Future, NewError>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        ResponseFuture {
+            response_future: self.inner.call(req),
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[pin_project]
+pub struct ResponseFuture<F, NewError> {
+    #[pin]
+    response_future: F,
+    _marker: PhantomData<NewError>,
+}
+
+impl<F, Response, Error, NewError> Future for ResponseFuture<F, NewError>
+where
+    F: Future<Output = Result<Response, Error>>,
+    Error: Into<NewError>,
+{
+    type Output = Result<Response, NewError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result_fut = this.response_future.poll(cx);
+        match result_fut {
+            Poll::Ready(result) => match result {
+                Ok(response) => Poll::Ready(Ok(response)),
+                Err(e) => Poll::Ready(Err(e.into())),
+            },
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/canhttp/src/convert/error.rs
+++ b/canhttp/src/convert/error.rs
@@ -6,12 +6,18 @@ use std::task::{Context, Poll};
 use tower::Service;
 use tower_layer::Layer;
 
+/// Convert error of a service into another type, where the conversion does *not* fail.
+///
+/// This [`Layer`] produces instances of the [`ConvertError`] service.
+///
+/// [`Layer`]: tower::Layer
 #[derive(Debug)]
 pub struct ConvertErrorLayer<E> {
     _marker: PhantomData<E>,
 }
 
 impl<E> ConvertErrorLayer<E> {
+    /// Returns a new [`ConvertErrorLayer`]
     pub fn new() -> Self {
         Self {
             _marker: PhantomData,
@@ -33,6 +39,7 @@ impl<E> Clone for ConvertErrorLayer<E> {
     }
 }
 
+/// Convert the inner service error to another type, where the conversion does *not* fail.
 #[derive(Debug)]
 pub struct ConvertError<S, E> {
     inner: S,

--- a/canhttp/src/convert/error.rs
+++ b/canhttp/src/convert/error.rs
@@ -11,11 +11,17 @@ pub struct ConvertErrorLayer<E> {
     _marker: PhantomData<E>,
 }
 
-impl<L> ConvertErrorLayer<L> {
+impl<E> ConvertErrorLayer<E> {
     pub fn new() -> Self {
         Self {
             _marker: PhantomData,
         }
+    }
+}
+
+impl<E> Default for ConvertErrorLayer<E> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/canhttp/src/convert/mod.rs
+++ b/canhttp/src/convert/mod.rs
@@ -134,6 +134,10 @@ pub trait ConvertServiceBuilder<L> {
     ///
     /// See the [module docs](crate::convert) for examples.
     fn convert_response<C>(self, f: C) -> ServiceBuilder<Stack<ConvertResponseLayer<C>, L>>;
+
+    /// Convert the error type.
+    ///
+    /// See the [module docs](crate::convert) for examples.
     fn convert_error<NewError>(self) -> ServiceBuilder<Stack<ConvertErrorLayer<NewError>, L>>;
 }
 

--- a/canhttp/src/convert/mod.rs
+++ b/canhttp/src/convert/mod.rs
@@ -98,6 +98,56 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! ## To convert errors
+//!
+//! A service that returns an error of type `Error` can be turned into a service that returns
+//! errors of type `NewError`, if `Error` can be converted `Into` the type `NewError`.
+//! This is automatically the case if `NewError` implements `From<Error>`.
+//!
+//! ```rust
+//! use canhttp::convert::{Convert, ConvertServiceBuilder};
+//! use tower::{ServiceBuilder, Service, ServiceExt};
+//!
+//!  enum Error {
+//!     OhNo
+//!  }
+//!  async fn bare_bone_service(request: Vec<u8>) -> Result<Vec<u8>, Error> {
+//!    Err(Error::OhNo)
+//!  }
+//!
+//! #[derive(Debug, PartialEq)]
+//! enum NewError {
+//!     Oops
+//! }
+//!
+//! impl From<Error> for NewError {
+//!     fn from(value: Error) -> Self {
+//!         match value {  
+//!             Error::OhNo => NewError::Oops
+//!         }
+//!     }
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut service = ServiceBuilder::new()
+//!     .convert_error::<NewError>()
+//!     .service_fn(bare_bone_service);
+//!
+//! let request = vec![42];
+//!
+//! let response = service
+//!     .ready()
+//!     .await
+//!     .unwrap()
+//!     .call(request)
+//!     .await;
+//!
+//! assert_eq!(response, Err(NewError::Oops));
+//! # Ok(())
+//! # }
+//! ```
 
 pub use error::{ConvertError, ConvertErrorLayer};
 pub use request::{ConvertRequest, ConvertRequestLayer};

--- a/canhttp/src/convert/mod.rs
+++ b/canhttp/src/convert/mod.rs
@@ -99,9 +99,11 @@
 //! # }
 //! ```
 
+pub use error::{ConvertError, ConvertErrorLayer};
 pub use request::{ConvertRequest, ConvertRequestLayer};
 pub use response::{ConvertResponse, ConvertResponseLayer};
 
+mod error;
 mod request;
 mod response;
 
@@ -132,6 +134,7 @@ pub trait ConvertServiceBuilder<L> {
     ///
     /// See the [module docs](crate::convert) for examples.
     fn convert_response<C>(self, f: C) -> ServiceBuilder<Stack<ConvertResponseLayer<C>, L>>;
+    fn convert_error<NewError>(self) -> ServiceBuilder<Stack<ConvertErrorLayer<NewError>, L>>;
 }
 
 impl<L> ConvertServiceBuilder<L> for ServiceBuilder<L> {
@@ -144,5 +147,9 @@ impl<L> ConvertServiceBuilder<L> for ServiceBuilder<L> {
         converter: C,
     ) -> ServiceBuilder<Stack<ConvertResponseLayer<C>, L>> {
         self.layer(ConvertResponseLayer::new(converter))
+    }
+
+    fn convert_error<NewError>(self) -> ServiceBuilder<Stack<ConvertErrorLayer<NewError>, L>> {
+        self.layer(ConvertErrorLayer::new())
     }
 }

--- a/canhttp/src/http/mod.rs
+++ b/canhttp/src/http/mod.rs
@@ -29,7 +29,7 @@
 //! # Examples
 //!
 //! ```rust
-//! use canhttp::{http::{HttpConversionLayer, MaxResponseBytesRequestExtension}, IcError};
+//! use canhttp::{http::{HttpConversionLayer }, IcError, MaxResponseBytesRequestExtension};
 //! use ic_cdk::api::management_canister::http_request::{CanisterHttpRequestArgument as IcHttpRequest, HttpResponse as IcHttpResponse};
 //! use tower::{Service, ServiceBuilder, ServiceExt, BoxError};
 //!
@@ -65,10 +65,7 @@
 #[cfg(test)]
 mod tests;
 
-pub use request::{
-    HttpRequest, HttpRequestConversionError, HttpRequestConverter,
-    MaxResponseBytesRequestExtension, TransformContextRequestExtension,
-};
+pub use request::{HttpRequest, HttpRequestConversionError, HttpRequestConverter};
 pub use response::{
     FilterNonSuccessfulHttpResponse, FilterNonSuccessulHttpResponseError, HttpResponse,
     HttpResponseConversionError, HttpResponseConverter,

--- a/canhttp/src/http/request.rs
+++ b/canhttp/src/http/request.rs
@@ -4,28 +4,10 @@ use ic_cdk::api::management_canister::http_request::{
     HttpMethod as IcHttpMethod, TransformContext,
 };
 use thiserror::Error;
+use crate::{MaxResponseBytesRequestExtension, TransformContextRequestExtension};
 
 /// HTTP request with a body made of bytes.
 pub type HttpRequest = http::Request<Vec<u8>>;
-
-/// Add support for max response bytes.
-pub trait MaxResponseBytesRequestExtension: Sized {
-    /// Set the max response bytes.
-    ///
-    /// If provided, the value must not exceed 2MB (2_000_000B).
-    /// The call will be charged based on this parameter.
-    /// If not provided, the maximum of 2MB will be used.
-    fn set_max_response_bytes(&mut self, value: u64);
-
-    /// Retrieves the current max response bytes value, if any.
-    fn get_max_response_bytes(&self) -> Option<u64>;
-
-    /// Convenience method to use the builder pattern.
-    fn max_response_bytes(mut self, value: u64) -> Self {
-        self.set_max_response_bytes(value);
-        self
-    }
-}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct MaxResponseBytesExtension(pub u64);
@@ -53,25 +35,6 @@ impl MaxResponseBytesRequestExtension for http::request::Builder {
     fn get_max_response_bytes(&self) -> Option<u64> {
         self.extensions_ref()
             .and_then(|extensions| extensions.get::<MaxResponseBytesExtension>().map(|e| e.0))
-    }
-}
-
-/// Add support for transform context to specify how the response will be canonicalized by the replica
-/// to maximize chances of consensus.
-///
-/// See the [docs](https://internetcomputer.org/docs/references/https-outcalls-how-it-works#transformation-function)
-/// on HTTPs outcalls for more details.
-pub trait TransformContextRequestExtension: Sized {
-    /// Set the transform context.
-    fn set_transform_context(&mut self, value: TransformContext);
-
-    /// Retrieve the current transform context, if any.
-    fn get_transform_context(&self) -> Option<&TransformContext>;
-
-    /// Convenience method to use the builder pattern.
-    fn transform_context(mut self, value: TransformContext) -> Self {
-        self.set_transform_context(value);
-        self
     }
 }
 

--- a/canhttp/src/http/request.rs
+++ b/canhttp/src/http/request.rs
@@ -1,10 +1,10 @@
 use crate::convert::Convert;
+use crate::{MaxResponseBytesRequestExtension, TransformContextRequestExtension};
 use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument as IcHttpRequest, HttpHeader as IcHttpHeader,
     HttpMethod as IcHttpMethod, TransformContext,
 };
 use thiserror::Error;
-use crate::{MaxResponseBytesRequestExtension, TransformContextRequestExtension};
 
 /// HTTP request with a body made of bytes.
 pub type HttpRequest = http::Request<Vec<u8>>;

--- a/canhttp/src/http/tests.rs
+++ b/canhttp/src/http/tests.rs
@@ -1,10 +1,10 @@
 use crate::http::request::HttpRequestConversionError;
 use crate::http::response::{HttpResponse, HttpResponseConversionError};
-use crate::http::{
-    HttpConversionLayer, HttpRequestConverter, HttpResponseConverter,
-    MaxResponseBytesRequestExtension, TransformContextRequestExtension,
+use crate::http::{HttpConversionLayer, HttpRequestConverter, HttpResponseConverter};
+use crate::{
+    ConvertServiceBuilder, IcError, MaxResponseBytesRequestExtension,
+    TransformContextRequestExtension,
 };
-use crate::{ConvertServiceBuilder, IcError};
 use assert_matches::assert_matches;
 use candid::{Decode, Encode, Principal};
 use http::StatusCode;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -10,6 +10,7 @@ pub use convert::ConvertServiceBuilder;
 pub use cycles::{
     CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, CyclesCostEstimator,
 };
+use ic_cdk::api::management_canister::http_request::TransformContext;
 
 mod client;
 pub mod convert;
@@ -17,3 +18,41 @@ mod cycles;
 #[cfg(feature = "http")]
 pub mod http;
 pub mod observability;
+
+/// Add support for max response bytes.
+pub trait MaxResponseBytesRequestExtension: Sized {
+    /// Set the max response bytes.
+    ///
+    /// If provided, the value must not exceed 2MB (2_000_000B).
+    /// The call will be charged based on this parameter.
+    /// If not provided, the maximum of 2MB will be used.
+    fn set_max_response_bytes(&mut self, value: u64);
+
+    /// Retrieves the current max response bytes value, if any.
+    fn get_max_response_bytes(&self) -> Option<u64>;
+
+    /// Convenience method to use the builder pattern.
+    fn max_response_bytes(mut self, value: u64) -> Self {
+        self.set_max_response_bytes(value);
+        self
+    }
+}
+
+/// Add support for transform context to specify how the response will be canonicalized by the replica
+/// to maximize chances of consensus.
+///
+/// See the [docs](https://internetcomputer.org/docs/references/https-outcalls-how-it-works#transformation-function)
+/// on HTTPs outcalls for more details.
+pub trait TransformContextRequestExtension: Sized {
+    /// Set the transform context.
+    fn set_transform_context(&mut self, value: TransformContext);
+
+    /// Retrieve the current transform context, if any.
+    fn get_transform_context(&self) -> Option<&TransformContext>;
+
+    /// Convenience method to use the builder pattern.
+    fn transform_context(mut self, value: TransformContext) -> Self {
+        self.set_transform_context(value);
+        self
+    }
+}

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -3,8 +3,7 @@
 //! leveraging the modularity of the [tower framework](https://rust-lang.guide/guide/learn-async-rust/tower.html).
 
 #![forbid(unsafe_code)]
-// TODO: XC-287 reenable docs
-// #![forbid(missing_docs)]
+#![forbid(missing_docs)]
 
 pub use client::{Client, IcError, IcHttpRequestWithCycles};
 pub use convert::ConvertServiceBuilder;
@@ -59,6 +58,7 @@ pub trait TransformContextRequestExtension: Sized {
     }
 }
 
+/// Characterize errors that are specific to HTTPs outcalls.
 pub trait HttpsOutcallError {
     /// Determines whether the error indicates that the response was larger than the specified
     /// [`max_response_bytes`](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-http_request) specified in the request.

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -5,13 +5,14 @@
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
 
-pub use client::{Client, IcError, IcHttpRequestWithCycles};
+pub use client::{
+    Client, HttpsOutcallError, IcError, IcHttpRequestWithCycles, MaxResponseBytesRequestExtension,
+    TransformContextRequestExtension,
+};
 pub use convert::ConvertServiceBuilder;
 pub use cycles::{
     CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, CyclesCostEstimator,
 };
-use ic_cdk::api::management_canister::http_request::TransformContext;
-
 mod client;
 pub mod convert;
 mod cycles;
@@ -19,50 +20,3 @@ mod cycles;
 pub mod http;
 pub mod observability;
 pub mod retry;
-
-/// Add support for max response bytes.
-pub trait MaxResponseBytesRequestExtension: Sized {
-    /// Set the max response bytes.
-    ///
-    /// If provided, the value must not exceed 2MB (2_000_000B).
-    /// The call will be charged based on this parameter.
-    /// If not provided, the maximum of 2MB will be used.
-    fn set_max_response_bytes(&mut self, value: u64);
-
-    /// Retrieves the current max response bytes value, if any.
-    fn get_max_response_bytes(&self) -> Option<u64>;
-
-    /// Convenience method to use the builder pattern.
-    fn max_response_bytes(mut self, value: u64) -> Self {
-        self.set_max_response_bytes(value);
-        self
-    }
-}
-
-/// Add support for transform context to specify how the response will be canonicalized by the replica
-/// to maximize chances of consensus.
-///
-/// See the [docs](https://internetcomputer.org/docs/references/https-outcalls-how-it-works#transformation-function)
-/// on HTTPs outcalls for more details.
-pub trait TransformContextRequestExtension: Sized {
-    /// Set the transform context.
-    fn set_transform_context(&mut self, value: TransformContext);
-
-    /// Retrieve the current transform context, if any.
-    fn get_transform_context(&self) -> Option<&TransformContext>;
-
-    /// Convenience method to use the builder pattern.
-    fn transform_context(mut self, value: TransformContext) -> Self {
-        self.set_transform_context(value);
-        self
-    }
-}
-
-/// Characterize errors that are specific to HTTPs outcalls.
-pub trait HttpsOutcallError {
-    /// Determines whether the error indicates that the response was larger than the specified
-    /// [`max_response_bytes`](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-http_request) specified in the request.
-    ///
-    /// If true, retrying with a larger value for `max_response_bytes` may help.
-    fn is_response_too_large(&self) -> bool;
-}

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -3,7 +3,8 @@
 //! leveraging the modularity of the [tower framework](https://rust-lang.guide/guide/learn-async-rust/tower.html).
 
 #![forbid(unsafe_code)]
-#![forbid(missing_docs)]
+// TODO: XC-287 reenable docs
+// #![forbid(missing_docs)]
 
 pub use client::{Client, IcError, IcHttpRequestWithCycles};
 pub use convert::ConvertServiceBuilder;

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -18,6 +18,7 @@ mod cycles;
 #[cfg(feature = "http")]
 pub mod http;
 pub mod observability;
+pub mod retry;
 
 /// Add support for max response bytes.
 pub trait MaxResponseBytesRequestExtension: Sized {
@@ -55,4 +56,12 @@ pub trait TransformContextRequestExtension: Sized {
         self.set_transform_context(value);
         self
     }
+}
+
+pub trait HttpsOutcallError {
+    /// Determines whether the error indicates that the response was larger than the specified
+    /// [`max_response_bytes`](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-http_request) specified in the request.
+    ///
+    /// If true, retrying with a larger value for `max_response_bytes` may help.
+    fn is_response_too_large(&self) -> bool;
 }

--- a/canhttp/src/observability/mod.rs
+++ b/canhttp/src/observability/mod.rs
@@ -172,6 +172,7 @@ use tower::{Layer, Service};
 ///
 /// [`Layer`]: tower::Layer
 /// [`Service`]: tower::Service
+#[derive(Clone, Debug)]
 pub struct ObservabilityLayer<OnRequest, OnResponse, OnError> {
     on_request: OnRequest,
     on_response: OnResponse,
@@ -263,6 +264,7 @@ where
 /// See the [module docs](crate::observability) for an example.
 ///
 /// [`Service`]: tower::Service
+#[derive(Clone, Debug)]
 pub struct Observability<S, OnRequest, OnResponse, OnError> {
     inner: S,
     on_request: OnRequest,

--- a/canhttp/src/retry/mod.rs
+++ b/canhttp/src/retry/mod.rs
@@ -1,0 +1,52 @@
+use crate::{HttpsOutcallError, MaxResponseBytesRequestExtension};
+use std::future;
+use tower::retry;
+
+// This constant comes from the IC specification:
+// > If provided, the value must not exceed 2MB
+const HTTP_MAX_SIZE: u64 = 2_000_000;
+
+/// Double the `max_response_bytes` in case the IC error indicates the response was too big.
+#[derive(Debug, Clone)]
+pub struct DoubleMaxResponseBytes;
+
+impl<Request, Response, Error> retry::Policy<Request, Response, Error> for DoubleMaxResponseBytes
+where
+    Request: MaxResponseBytesRequestExtension + Clone,
+    Error: HttpsOutcallError,
+{
+    type Future = future::Ready<()>;
+
+    fn retry(
+        &mut self,
+        req: &mut Request,
+        result: &mut Result<Response, Error>,
+    ) -> Option<Self::Future> {
+        match result {
+            Err(e) if e.is_response_too_large() => {
+                if let Some(previous_estimate) = req.get_max_response_bytes() {
+                    let new_estimate = previous_estimate
+                        .max(1024)
+                        .saturating_mul(2)
+                        .min(HTTP_MAX_SIZE);
+                    if new_estimate > previous_estimate {
+                        req.set_max_response_bytes(new_estimate);
+                        return Some(future::ready(()));
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    fn clone_request(&mut self, req: &Request) -> Option<Request> {
+        match req.get_max_response_bytes() {
+            Some(max_response_bytes) if max_response_bytes < HTTP_MAX_SIZE => Some(req.clone()),
+            // Not having a value is equivalent to setting `max_response_bytes` to the maximum value.
+            // If there is a value, it's at least the maximum value.
+            // In both cases retrying will not help.
+            _ => None,
+        }
+    }
+}

--- a/canhttp/src/retry/mod.rs
+++ b/canhttp/src/retry/mod.rs
@@ -1,3 +1,8 @@
+//! Middleware for retrying "failed" requests.
+
+#[cfg(test)]
+mod tests;
+
 use crate::{HttpsOutcallError, MaxResponseBytesRequestExtension};
 use std::future;
 use tower::retry;

--- a/canhttp/src/retry/tests.rs
+++ b/canhttp/src/retry/tests.rs
@@ -1,0 +1,194 @@
+use crate::http::HttpRequest;
+use crate::retry::DoubleMaxResponseBytes;
+use crate::{HttpsOutcallError, IcError, MaxResponseBytesRequestExtension};
+use assert_matches::assert_matches;
+use ic_cdk::api::call::RejectionCode;
+use std::future;
+use std::sync::mpsc;
+use std::sync::mpsc::Sender;
+use std::task::{Context, Poll};
+use tower::{Service, ServiceBuilder, ServiceExt};
+
+#[tokio::test]
+async fn should_retry_until_max() {
+    let (requests_tx, requests_rx) = mpsc::channel::<HttpRequest>();
+
+    let mut service =
+        ServiceBuilder::new()
+            .retry(DoubleMaxResponseBytes)
+            .service(StoreRequestServiceAndError::<HttpRequest>::always_error(
+                requests_tx.clone(),
+            ));
+
+    let request = http::Request::post("https://internetcomputer.org/")
+        .max_response_bytes(0)
+        .body(vec![])
+        .unwrap();
+
+    let response = service
+        .ready()
+        .await
+        .unwrap()
+        .call(request)
+        .await
+        .unwrap_err();
+    assert!(response.is_response_too_large());
+
+    let mut all_requests = Vec::new();
+    let mut iter = requests_rx.try_iter();
+    while let Some(req) = iter.next() {
+        all_requests.push(req);
+    }
+
+    assert_eq!(all_requests.len(), 12);
+    assert_eq!(
+        all_requests
+            .into_iter()
+            .map(|r| r.get_max_response_bytes().unwrap())
+            .collect::<Vec<_>>(),
+        vec![
+            0,
+            1024 << 1,
+            1024 << 2,
+            1024 << 3,
+            1024 << 4,
+            1024 << 5,
+            1024 << 6,
+            1024 << 7,
+            1024 << 8,
+            1024 << 9,
+            1024 << 10,
+            2_000_000
+        ]
+    );
+}
+
+#[tokio::test]
+async fn should_not_retry() {
+    for max_response_bytes in [Some(2_000_000_u64), None] {
+        let (requests_tx, requests_rx) = mpsc::channel::<HttpRequest>();
+
+        let mut service = ServiceBuilder::new().retry(DoubleMaxResponseBytes).service(
+            StoreRequestServiceAndError::<HttpRequest>::always_error(requests_tx.clone()),
+        );
+
+        let mut builder = http::Request::post("https://internetcomputer.org/");
+        if let Some(max_response_bytes) = max_response_bytes {
+            builder = builder.max_response_bytes(max_response_bytes);
+        }
+        let request = builder.body(vec![]).unwrap();
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap_err();
+        assert!(response.is_response_too_large());
+
+        let mut all_requests = Vec::new();
+        let mut iter = requests_rx.try_iter();
+        while let Some(req) = iter.next() {
+            all_requests.push(req);
+        }
+        assert_eq!(all_requests.len(), 1);
+    }
+}
+
+#[tokio::test]
+async fn should_stop_retrying_when_ok() {
+    let (requests_tx, requests_rx) = mpsc::channel::<HttpRequest>();
+
+    let num_errors = 3;
+    let mut service =
+        ServiceBuilder::new()
+            .retry(DoubleMaxResponseBytes)
+            .service(StoreRequestServiceAndError::<HttpRequest>::error_n_times(
+                requests_tx.clone(),
+                num_errors,
+            ));
+
+    let request = http::Request::post("https://internetcomputer.org/")
+        .max_response_bytes(0)
+        .body(vec![])
+        .unwrap();
+
+    let response = service.ready().await.unwrap().call(request).await;
+    assert_matches!(response, Ok(_));
+
+    let mut all_requests = Vec::new();
+    let mut iter = requests_rx.try_iter();
+    while let Some(req) = iter.next() {
+        all_requests.push(req);
+    }
+
+    assert_eq!(all_requests.len(), (num_errors + 1) as usize);
+    assert_eq!(
+        all_requests
+            .into_iter()
+            .map(|r| r.get_max_response_bytes().unwrap())
+            .collect::<Vec<_>>(),
+        vec![0, 1024 << 1, 1024 << 2, 1024 << 3]
+    );
+}
+
+#[derive(Clone, Debug)]
+pub struct StoreRequestServiceAndError<T> {
+    requests: Sender<T>,
+    num_calls: u8,
+    num_errors_before_ok: u8,
+}
+
+impl<T> StoreRequestServiceAndError<T> {
+    pub fn always_error(requests: Sender<T>) -> Self {
+        Self {
+            requests,
+            num_calls: 0,
+            num_errors_before_ok: u8::MAX,
+        }
+    }
+
+    pub fn error_n_times(requests: Sender<T>, num_errors: u8) -> Self {
+        Self {
+            requests,
+            num_calls: 0,
+            num_errors_before_ok: num_errors,
+        }
+    }
+}
+
+impl<Request> Service<Request> for StoreRequestServiceAndError<Request>
+where
+    Request: Clone,
+{
+    type Response = Request;
+    type Error = IcError;
+    type Future = future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        self.num_calls = self
+            .num_calls
+            .checked_add(1)
+            .expect("Unexpected large number of calls to service");
+        self.requests.send(req.clone()).unwrap();
+        if self.num_calls <= self.num_errors_before_ok {
+            future::ready(Err(response_is_too_large_error()))
+        } else {
+            future::ready(Ok(req))
+        }
+    }
+}
+
+fn response_is_too_large_error() -> IcError {
+    let error = IcError {
+        code: RejectionCode::SysFatal,
+        message: "Http body exceeds size limit".to_string(),
+    };
+    assert!(error.is_response_too_large());
+    error
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -18,10 +18,11 @@ use canhttp::{
         },
         FilterNonSuccessfulHttpResponse, FilterNonSuccessulHttpResponseError,
         HttpRequestConversionError, HttpRequestConverter, HttpResponseConversionError,
-        HttpResponseConverter, MaxResponseBytesRequestExtension, TransformContextRequestExtension,
+        HttpResponseConverter,
     },
     observability::ObservabilityLayer,
     ConvertServiceBuilder, CyclesAccounting, CyclesAccountingError, CyclesChargingPolicy, IcError,
+    MaxResponseBytesRequestExtension, TransformContextRequestExtension,
 };
 use evm_rpc_types::{HttpOutcallError, ProviderError, RpcError, RpcResult, ValidationError};
 use http::header::CONTENT_TYPE;

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -12,8 +12,10 @@ use crate::rpc_client::json::responses::{
 use crate::rpc_client::numeric::{TransactionCount, Wei};
 use crate::types::MetricRpcMethod;
 use candid::candid_method;
-use canhttp::http::json::JsonRpcRequestBody;
-use canhttp::http::{MaxResponseBytesRequestExtension, TransformContextRequestExtension};
+use canhttp::{
+    http::json::JsonRpcRequestBody, MaxResponseBytesRequestExtension,
+    TransformContextRequestExtension,
+};
 use evm_rpc_types::{HttpOutcallError, JsonRpcError, RpcError, RpcService};
 use ic_canister_log::log;
 use ic_cdk::api::call::RejectionCode;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -601,6 +601,31 @@ fn should_canonicalize_json_response() {
 }
 
 #[test]
+fn should_not_modify_json_rpc_request_from_request_endpoint() {
+    let setup = EvmRpcSetup::new();
+
+    let json_rpc_request = r#"{"id":123,"jsonrpc":"2.0","method":"eth_gasPrice"}"#;
+    let mock_response = r#"{"jsonrpc":"2.0","id":123,"result":"0x00112233"}"#;
+
+    let response = setup
+        .request(
+            RpcService::Custom(RpcApi {
+                url: MOCK_REQUEST_URL.to_string(),
+                headers: None,
+            }),
+            json_rpc_request,
+            MOCK_REQUEST_RESPONSE_BYTES,
+        )
+        .mock_http_once(
+            MockOutcallBuilder::new(200, mock_response).with_raw_request_body(json_rpc_request),
+        )
+        .wait()
+        .unwrap();
+
+    assert_eq!(response, mock_response);
+}
+
+#[test]
 fn should_decode_renamed_field() {
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, CandidType)]
     pub struct Struct {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2143,7 +2143,7 @@ fn should_retry_when_response_too_large() {
         .mock_http_once(mock.clone().with_max_response_bytes(1024 << 8))
         .mock_http_once(mock.clone().with_max_response_bytes(1024 << 9))
         .mock_http_once(mock.clone().with_max_response_bytes(1024 << 10))
-        .mock_http_once(mock.clone().with_max_response_bytes(2_000_000 - 2 * 1024))
+        .mock_http_once(mock.clone().with_max_response_bytes(2_000_000))
         .wait()
         .expect_consistent();
 


### PR DESCRIPTION
Follow-up on #370,  #364,  #374, and #375 to automatically retry requests by doubling its `max_response_bytes` when the response was too big. 