### PR TITLE
refactor: adapt JSON RPC request and response types according to the specification

### DIFF
--- a/canhttp/src/http/json/id.rs
+++ b/canhttp/src/http/json/id.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
-/// An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts
+/// An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
+/// 
+/// If it is not included it is assumed to be a notification.
+/// The value SHOULD normally not be Null.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Id {
@@ -20,6 +23,7 @@ pub enum Id {
 }
 
 impl Id {
+    /// Zero numeric ID.
     pub const ZERO: Id = Id::Number(0);
 }
 

--- a/canhttp/src/http/json/id.rs
+++ b/canhttp/src/http/json/id.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+
+/// An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Id {
+    /// Numeric ID.
+    Number(u64),
+
+    /// String ID
+    String(String),
+
+    /// Null ID.
+    ///
+    /// The use of `Null` as a value for the id member in a Request object is discouraged,
+    /// because this specification uses a value of Null for Responses with an unknown id.
+    /// Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.
+    Null,
+}
+
+impl Display for Id {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Id::Number(id) => Display::fmt(id, f),
+            Id::String(id) => Display::fmt(id, f),
+            Id::Null => f.write_str("null"),
+        }
+    }
+}

--- a/canhttp/src/http/json/id.rs
+++ b/canhttp/src/http/json/id.rs
@@ -19,6 +19,16 @@ pub enum Id {
     Null,
 }
 
+impl Id {
+    pub const ZERO: Id = Id::Number(0);
+}
+
+impl<T: Into<u64>> From<T> for Id {
+    fn from(value: T) -> Self {
+        Id::Number(value.into())
+    }
+}
+
 impl Display for Id {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/canhttp/src/http/json/id.rs
+++ b/canhttp/src/http/json/id.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
 /// An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
-/// 
+///
 /// If it is not included it is assumed to be a notification.
 /// The value SHOULD normally not be Null.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -52,7 +52,7 @@
 use crate::convert::{ConvertRequest, ConvertRequestLayer, ConvertResponse, ConvertResponseLayer};
 pub use id::Id;
 pub use request::{
-    HttpJsonRpcRequest, JsonRequestConversionError, JsonRequestConverter, JsonRpcRequestBody,
+    HttpJsonRpcRequest, JsonRequestConversionError, JsonRequestConverter, JsonRpcRequest,
 };
 pub use response::{
     HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConverter, JsonRpcError,

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -56,7 +56,7 @@ pub use request::{
 };
 pub use response::{
     HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConverter, JsonRpcResponseBody,
-    JsonRpcResult,
+    JsonRpcResult, JsonRpcError
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -56,7 +56,7 @@ pub use request::{
 };
 pub use response::{
     HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConverter, JsonRpcError,
-    JsonRpcResponseBody, JsonRpcResult,
+    JsonRpcResponse, JsonRpcResult,
 };
 pub use version::Version;
 

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -58,6 +58,8 @@ pub use response::{
     HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConverter, JsonRpcError,
     JsonRpcResponseBody, JsonRpcResult,
 };
+pub use version::Version;
+
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::marker::PhantomData;
@@ -69,6 +71,7 @@ mod tests;
 mod id;
 mod request;
 mod response;
+mod version;
 
 /// Middleware that combines [`JsonRequestConverter`] to convert requests
 /// and [`JsonResponseConverter`] to convert responses to a [`Service`].

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -55,8 +55,8 @@ pub use request::{
     HttpJsonRpcRequest, JsonRequestConversionError, JsonRequestConverter, JsonRpcRequestBody,
 };
 pub use response::{
-    HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConverter, JsonRpcResponseBody,
-    JsonRpcResult, JsonRpcError
+    HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConverter, JsonRpcError,
+    JsonRpcResponseBody, JsonRpcResult,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -50,6 +50,7 @@
 //! # }
 
 use crate::convert::{ConvertRequest, ConvertRequestLayer, ConvertResponse, ConvertResponseLayer};
+pub use id::Id;
 pub use request::{
     HttpJsonRpcRequest, JsonRequestConversionError, JsonRequestConverter, JsonRpcRequestBody,
 };
@@ -65,6 +66,7 @@ use tower_layer::Layer;
 #[cfg(test)]
 mod tests;
 
+mod id;
 mod request;
 mod response;
 

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -54,7 +54,8 @@ pub use request::{
     HttpJsonRpcRequest, JsonRequestConversionError, JsonRequestConverter, JsonRpcRequestBody,
 };
 pub use response::{
-    HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConverter, JsonRpcResult,
+    HttpJsonRpcResponse, JsonResponseConversionError, JsonResponseConverter, JsonRpcResponseBody,
+    JsonRpcResult,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -1,4 +1,5 @@
 use crate::convert::Convert;
+use crate::http::json::Id;
 use crate::http::HttpRequest;
 use http::header::CONTENT_TYPE;
 use http::HeaderValue;
@@ -88,7 +89,7 @@ pub type HttpJsonRpcRequest<T> = http::Request<JsonRpcRequestBody<T>>;
 pub struct JsonRpcRequestBody<T> {
     jsonrpc: String,
     method: String,
-    id: Option<serde_json::Value>,
+    id: Id,
     params: Option<T>,
 }
 
@@ -98,19 +99,19 @@ impl<T> JsonRpcRequestBody<T> {
         Self {
             jsonrpc: "2.0".to_string(),
             method: method.into(),
-            id: Some(serde_json::Value::Number(0.into())),
+            id: Id::ZERO,
             params: Some(params),
         }
     }
 
     /// Change the request ID.
-    pub fn set_id(&mut self, id: u64) {
-        self.id = Some(serde_json::Value::Number(id.into()));
+    pub fn set_id(&mut self, id: Id) {
+        self.id = id;
     }
 
     /// Returns the request ID, if any.
-    pub fn id(&self) -> Option<&serde_json::Value> {
-        self.id.as_ref()
+    pub fn id(&self) -> &Id {
+        &self.id
     }
 
     /// Returns the JSON-RPC method.

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -104,6 +104,11 @@ impl<T> JsonRpcRequestBody<T> {
         }
     }
 
+    /// Change the request ID following the builder pattern.
+    pub fn with_id(self, id: Id) -> Self {
+        Self { id, ..self }
+    }
+
     /// Change the request ID.
     pub fn set_id(&mut self, id: Id) {
         self.id = id;

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -1,5 +1,5 @@
 use crate::convert::Convert;
-use crate::http::json::Id;
+use crate::http::json::{Id, Version};
 use crate::http::HttpRequest;
 use http::header::CONTENT_TYPE;
 use http::HeaderValue;
@@ -87,7 +87,7 @@ pub type HttpJsonRpcRequest<T> = http::Request<JsonRpcRequestBody<T>>;
 /// Body for all JSON-RPC requests, see the [specification](https://www.jsonrpc.org/specification).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JsonRpcRequestBody<T> {
-    jsonrpc: String,
+    jsonrpc: Version,
     method: String,
     id: Id,
     params: Option<T>,
@@ -97,7 +97,7 @@ impl<T> JsonRpcRequestBody<T> {
     /// Create a new body of a JSON-RPC request.
     pub fn new(method: impl Into<String>, params: T) -> Self {
         Self {
-            jsonrpc: "2.0".to_string(),
+            jsonrpc: Version::V2,
             method: method.into(),
             id: Id::ZERO,
             params: Some(params),

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -82,18 +82,18 @@ fn add_content_type_header_if_missing(mut request: HttpRequest) -> HttpRequest {
 }
 
 /// JSON-RPC request.
-pub type HttpJsonRpcRequest<T> = http::Request<JsonRpcRequestBody<T>>;
+pub type HttpJsonRpcRequest<T> = http::Request<JsonRpcRequest<T>>;
 
 /// Body for all JSON-RPC requests, see the [specification](https://www.jsonrpc.org/specification).
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JsonRpcRequestBody<T> {
+pub struct JsonRpcRequest<T> {
     jsonrpc: Version,
     method: String,
     id: Id,
     params: Option<T>,
 }
 
-impl<T> JsonRpcRequestBody<T> {
+impl<T> JsonRpcRequest<T> {
     /// Create a new body of a JSON-RPC request.
     pub fn new(method: impl Into<String>, params: T) -> Self {
         Self {

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -74,7 +74,7 @@ where
     }
 }
 
-/// JSON-RPC response.
+/// JSON-RPC response over HTTP.
 pub type HttpJsonRpcResponse<T> = http::Response<JsonRpcResponseBody<T>>;
 pub type JsonRpcResult<T> = Result<T, JsonRpcError>;
 
@@ -92,7 +92,7 @@ impl<T> JsonRpcResponseBody<T> {
     pub fn from_ok(id: Id, result: T) -> Self {
         Self {
             jsonrpc: "2.0".to_string(),
-            result: JsonRpcResultEnvelope::Ok { result },
+            result: JsonRpcResultEnvelope::Ok(result),
             id,
         }
     }
@@ -101,7 +101,7 @@ impl<T> JsonRpcResponseBody<T> {
     pub fn from_error(id: Id, error: JsonRpcError) -> Self {
         Self {
             jsonrpc: "2.0".to_string(),
-            result: JsonRpcResultEnvelope::Err { error },
+            result: JsonRpcResultEnvelope::Err(error),
             id,
         }
     }
@@ -128,26 +128,27 @@ impl<T> JsonRpcResponseBody<T> {
 
 /// An envelope for all JSON-RPC responses.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 enum JsonRpcResultEnvelope<T> {
     /// Successful JSON-RPC response
-    Ok { result: T },
+    #[serde(rename = "result")]
+    Ok(T),
     /// Failed JSON-RPC response
-    Err { error: JsonRpcError },
+    #[serde(rename = "error")]
+    Err(JsonRpcError),
 }
 
 impl<T> JsonRpcResultEnvelope<T> {
     pub fn into_result(self) -> JsonRpcResult<T> {
         match self {
-            JsonRpcResultEnvelope::Ok { result } => Ok(result),
-            JsonRpcResultEnvelope::Err { error } => Err(error),
+            JsonRpcResultEnvelope::Ok(result) => Ok(result),
+            JsonRpcResultEnvelope::Err(error) => Err(error),
         }
     }
 
     pub fn as_result_mut(&mut self) -> Result<&mut T, &mut JsonRpcError> {
         match self {
-            JsonRpcResultEnvelope::Ok { result } => Ok(result),
-            JsonRpcResultEnvelope::Err { error } => Err(error),
+            JsonRpcResultEnvelope::Ok(result) => Ok(result),
+            JsonRpcResultEnvelope::Err(error) => Err(error),
         }
     }
 }

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -1,5 +1,5 @@
 use crate::convert::Convert;
-use crate::http::json::Id;
+use crate::http::json::{Id, Version};
 use crate::http::HttpResponse;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -81,7 +81,7 @@ pub type JsonRpcResult<T> = Result<T, JsonRpcError>;
 /// Body of a JSON-RPC response
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JsonRpcResponseBody<T> {
-    pub jsonrpc: String,
+    jsonrpc: Version,
     id: Id,
     #[serde(flatten)]
     result: JsonRpcResultEnvelope<T>,
@@ -91,7 +91,7 @@ impl<T> JsonRpcResponseBody<T> {
     /// Creates a new successful response from a request ID and `Error` object.
     pub fn from_ok(id: Id, result: T) -> Self {
         Self {
-            jsonrpc: "2.0".to_string(),
+            jsonrpc: Version::V2,
             result: JsonRpcResultEnvelope::Ok(result),
             id,
         }
@@ -100,7 +100,7 @@ impl<T> JsonRpcResponseBody<T> {
     /// Creates a new error response from a request ID and `Error` object.
     pub fn from_error(id: Id, error: JsonRpcError) -> Self {
         Self {
-            jsonrpc: "2.0".to_string(),
+            jsonrpc: Version::V2,
             result: JsonRpcResultEnvelope::Err(error),
             id,
         }

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -75,23 +75,23 @@ where
 }
 
 /// JSON-RPC response over HTTP.
-pub type HttpJsonRpcResponse<T> = http::Response<JsonRpcResponseBody<T>>;
+pub type HttpJsonRpcResponse<T> = http::Response<JsonRpcResponse<T>>;
 
 /// A specialized [`Result`] error type for JSON-RPC responses.
 ///
 /// [`Result`]: enum@std::result::Result
 pub type JsonRpcResult<T> = Result<T, JsonRpcError>;
 
-/// Body of a JSON-RPC response
+/// JSON-RPC response.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JsonRpcResponseBody<T> {
+pub struct JsonRpcResponse<T> {
     jsonrpc: Version,
     id: Id,
     #[serde(flatten)]
     result: JsonRpcResultEnvelope<T>,
 }
 
-impl<T> JsonRpcResponseBody<T> {
+impl<T> JsonRpcResponse<T> {
     /// Creates a new successful response from a request ID and `Error` object.
     pub const fn from_ok(id: Id, result: T) -> Self {
         Self {
@@ -113,8 +113,8 @@ impl<T> JsonRpcResponseBody<T> {
     /// Creates a new response from a request ID and either an `Ok(Value)` or `Err(Error)` body.
     pub fn from_parts(id: Id, result: JsonRpcResult<T>) -> Self {
         match result {
-            Ok(r) => JsonRpcResponseBody::from_ok(id, r),
-            Err(e) => JsonRpcResponseBody::from_error(id, e),
+            Ok(r) => JsonRpcResponse::from_ok(id, r),
+            Err(e) => JsonRpcResponse::from_error(id, e),
         }
     }
 

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use tower::{BoxError, Service, ServiceBuilder, ServiceExt};
 
 mod json_rpc {
-    use crate::http::json::{Id, JsonRpcError, JsonRpcRequest, JsonRpcResponseBody, Version};
+    use crate::http::json::{Id, JsonRpcError, JsonRpcRequest, JsonRpcResponse, Version};
     use assert_matches::assert_matches;
     use serde::de::DeserializeOwned;
     use serde_json::json;
@@ -50,7 +50,7 @@ mod json_rpc {
     fn should_deserialize_json_ok_response() {
         let error_response = json!({ "jsonrpc": "2.0", "result": 366632694, "id": 0 });
 
-        let json_response: JsonRpcResponseBody<u64> =
+        let json_response: JsonRpcResponse<u64> =
             serde_json::from_value(error_response).unwrap();
         let (id, result) = json_response.into_parts();
 
@@ -64,7 +64,7 @@ mod json_rpc {
             let error_response =
                 json!({"jsonrpc":"2.0", "id":0, "error": {"code":123, "message":"Error message"}});
 
-            let json_response: JsonRpcResponseBody<T> =
+            let json_response: JsonRpcResponse<T> =
                 serde_json::from_value(error_response).unwrap();
             let (id, result) = json_response.into_parts();
 

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use tower::{BoxError, Service, ServiceBuilder, ServiceExt};
 
 mod json_rpc {
-    use crate::http::json::{Id, JsonRpcError, JsonRpcRequestBody, JsonRpcResponseBody, Version};
+    use crate::http::json::{Id, JsonRpcError, JsonRpcRequest, JsonRpcResponseBody, Version};
     use assert_matches::assert_matches;
     use serde::de::DeserializeOwned;
     use serde_json::json;
@@ -39,7 +39,7 @@ mod json_rpc {
 
     #[test]
     fn should_serialize_request() {
-        let request = JsonRpcRequestBody::new("subtract", [43, 23]).with_id(Id::from(1_u8));
+        let request = JsonRpcRequest::new("subtract", [43, 23]).with_id(Id::from(1_u8));
         assert_eq!(
             serde_json::to_value(&request).unwrap(),
             json!({"jsonrpc": "2.0", "method": "subtract", "params": [43, 23], "id": 1})

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -6,7 +6,8 @@ use serde_json::json;
 use tower::{BoxError, Service, ServiceBuilder, ServiceExt};
 
 mod json_rpc {
-    use crate::http::json::{Id, JsonRpcError, JsonRpcResponseBody};
+    use crate::http::json::{Id, JsonRpcError, JsonRpcResponseBody, Version};
+    use assert_matches::assert_matches;
     use serde::de::DeserializeOwned;
     use serde_json::json;
     use std::fmt::Debug;
@@ -66,6 +67,24 @@ mod json_rpc {
         check::<serde_json::Value>();
         check::<Option<serde_json::Value>>();
         check::<Result<serde_json::Value, String>>();
+    }
+
+    #[test]
+    fn should_serialize_version() {
+        assert_eq!(serde_json::to_value(&Version::V2).unwrap(), json!("2.0"));
+    }
+
+    #[test]
+    fn should_deserialize_version() {
+        let version: Version = serde_json::from_value(json!("2.0")).unwrap();
+        assert_eq!(version, Version::V2);
+    }
+
+    #[test]
+    fn should_fail_to_deserialize_unknown_versions() {
+        for version in [json!("1.0"), json!("3.0"), json!("unexpected")] {
+            assert_matches!(serde_json::from_value::<Version>(version), Err(_));
+        }
     }
 }
 

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use tower::{BoxError, Service, ServiceBuilder, ServiceExt};
 
 mod json_rpc {
-    use crate::http::json::{Id, JsonRpcError, JsonRpcResponseBody, Version};
+    use crate::http::json::{Id, JsonRpcError, JsonRpcRequestBody, JsonRpcResponseBody, Version};
     use assert_matches::assert_matches;
     use serde::de::DeserializeOwned;
     use serde_json::json;
@@ -35,6 +35,15 @@ mod json_rpc {
         for value in [json!(true), json!(["array"]), json!({"an": "object"})] {
             let _error = serde_json::from_value::<Id>(value).expect_err("should fail");
         }
+    }
+
+    #[test]
+    fn should_serialize_request() {
+        let request = JsonRpcRequestBody::new("subtract", [43, 23]).with_id(Id::from(1_u8));
+        assert_eq!(
+            serde_json::to_value(&request).unwrap(),
+            json!({"jsonrpc": "2.0", "method": "subtract", "params": [43, 23], "id": 1})
+        )
     }
 
     #[test]

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -50,8 +50,7 @@ mod json_rpc {
     fn should_deserialize_json_ok_response() {
         let error_response = json!({ "jsonrpc": "2.0", "result": 366632694, "id": 0 });
 
-        let json_response: JsonRpcResponse<u64> =
-            serde_json::from_value(error_response).unwrap();
+        let json_response: JsonRpcResponse<u64> = serde_json::from_value(error_response).unwrap();
         let (id, result) = json_response.into_parts();
 
         assert_eq!(id, Id::ZERO);
@@ -64,8 +63,7 @@ mod json_rpc {
             let error_response =
                 json!({"jsonrpc":"2.0", "id":0, "error": {"code":123, "message":"Error message"}});
 
-            let json_response: JsonRpcResponse<T> =
-                serde_json::from_value(error_response).unwrap();
+            let json_response: JsonRpcResponse<T> = serde_json::from_value(error_response).unwrap();
             let (id, result) = json_response.into_parts();
 
             assert_eq!(id, Id::ZERO);

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -5,6 +5,36 @@ use http::HeaderValue;
 use serde_json::json;
 use tower::{BoxError, Service, ServiceBuilder, ServiceExt};
 
+mod json_rpc {
+    use crate::http::json::Id;
+    use serde_json::json;
+
+    #[test]
+    fn should_parse_null_id() {
+        let id: Id = serde_json::from_value(json!(null)).unwrap();
+        assert_eq!(id, Id::Null);
+    }
+
+    #[test]
+    fn should_parse_numeric_id() {
+        let id: Id = serde_json::from_value(json!(42)).unwrap();
+        assert_eq!(id, Id::Number(42));
+    }
+
+    #[test]
+    fn should_parse_string_id() {
+        let id: Id = serde_json::from_value(json!("forty two")).unwrap();
+        assert_eq!(id, Id::String("forty two".into()));
+    }
+
+    #[test]
+    fn should_fail_to_parse_id_from_wrong_types() {
+        for value in [json!(true), json!(["array"]), json!({"an": "object"})] {
+            let _error = serde_json::from_value::<Id>(value).expect_err("should fail");
+        }
+    }
+}
+
 #[tokio::test]
 async fn should_convert_json_request() {
     let url = "https://internetcomputer.org/";

--- a/canhttp/src/http/json/version.rs
+++ b/canhttp/src/http/json/version.rs
@@ -1,0 +1,52 @@
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+/// Protocol Version
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Version {
+    /// JSONRPC 2.0
+    V2,
+}
+
+impl Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Version::V2 => serializer.serialize_str("2.0"),
+        }
+    }
+}
+
+impl<'a> Deserialize<'a> for Version {
+    fn deserialize<D>(deserializer: D) -> Result<Version, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        deserializer.deserialize_identifier(VersionVisitor)
+    }
+}
+
+struct VersionVisitor;
+
+impl<'a> Visitor<'a> for VersionVisitor {
+    type Value = Version;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a string")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match value {
+            "2.0" => Ok(Version::V2),
+            _ => Err(serde::de::Error::custom(
+                "expected JSON-RPC version \"2.0\"",
+            )),
+        }
+    }
+}

--- a/canhttp/src/http/json/version.rs
+++ b/canhttp/src/http/json/version.rs
@@ -1,12 +1,21 @@
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
+use std::fmt::{Display, Formatter};
 
 /// Protocol Version
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Version {
     /// JSONRPC 2.0
     V2,
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Version::V2 => f.write_str("2.0"),
+        }
+    }
 }
 
 impl Serialize for Version {

--- a/canhttp/src/http/mod.rs
+++ b/canhttp/src/http/mod.rs
@@ -67,7 +67,7 @@ mod tests;
 
 pub use request::{HttpRequest, HttpRequestConversionError, HttpRequestConverter};
 pub use response::{
-    FilterNonSuccessfulHttpResponse, FilterNonSuccessulHttpResponseError, HttpResponse,
+    FilterNonSuccessfulHttpResponse, FilterNonSuccessfulHttpResponseError, HttpResponse,
     HttpResponseConversionError, HttpResponseConverter,
 };
 

--- a/canhttp/src/http/response.rs
+++ b/canhttp/src/http/response.rs
@@ -81,7 +81,7 @@ impl Convert<IcHttpResponse> for HttpResponseConverter {
 
 /// Error returned when converting responses with [`FilterNonSuccessfulHttpResponse`].
 #[derive(Error, Clone, Debug)]
-pub enum FilterNonSuccessulHttpResponseError<T> {
+pub enum FilterNonSuccessfulHttpResponseError<T> {
     /// Response has a non-successful status code.
     #[error("HTTP response is not successful: {0:?}")]
     UnsuccessfulResponse(http::Response<T>),
@@ -93,11 +93,11 @@ pub struct FilterNonSuccessfulHttpResponse;
 
 impl<T> Convert<http::Response<T>> for FilterNonSuccessfulHttpResponse {
     type Output = http::Response<T>;
-    type Error = FilterNonSuccessulHttpResponseError<T>;
+    type Error = FilterNonSuccessfulHttpResponseError<T>;
 
     fn try_convert(&mut self, response: Response<T>) -> Result<Self::Output, Self::Error> {
         if !response.status().is_success() {
-            return Err(FilterNonSuccessulHttpResponseError::UnsuccessfulResponse(
+            return Err(FilterNonSuccessfulHttpResponseError::UnsuccessfulResponse(
                 response,
             ));
         }

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -3,7 +3,8 @@
 //! leveraging the modularity of the [tower framework](https://rust-lang.guide/guide/learn-async-rust/tower.html).
 
 #![forbid(unsafe_code)]
-#![forbid(missing_docs)]
+// TODO XC-287: re-enable docs
+// #![forbid(missing_docs)]
 
 pub use client::{
     Client, HttpsOutcallError, IcError, IcHttpRequestWithCycles, MaxResponseBytesRequestExtension,

--- a/canhttp/src/lib.rs
+++ b/canhttp/src/lib.rs
@@ -3,8 +3,7 @@
 //! leveraging the modularity of the [tower framework](https://rust-lang.guide/guide/learn-async-rust/tower.html).
 
 #![forbid(unsafe_code)]
-// TODO XC-287: re-enable docs
-// #![forbid(missing_docs)]
+#![forbid(missing_docs)]
 
 pub use client::{
     Client, HttpsOutcallError, IcError, IcHttpRequestWithCycles, MaxResponseBytesRequestExtension,

--- a/e2e/motoko/main.mo
+++ b/e2e/motoko/main.mo
@@ -27,7 +27,6 @@ shared ({ caller = installer }) actor class Main() {
         (#EthMainnet(#BlockPi), ?"eth_sendRawTransaction"), // "Private transaction replacement (same nonce) with gas price change lower than 10% is not allowed within 30 sec from the previous transaction."
         (#EthMainnet(#Llama), ?"eth_sendRawTransaction"), // Non-standard error message
         (#ArbitrumOne(#Ankr), ?"eth_getLogs"), // Timeout expired
-        (#BaseMainnet(#Llama), null), // No response (temporary issue)
         (#OptimismMainnet(#BlockPi), ?"eth_feeHistory"), // Temporary issue with [op-geth](https://github.com/ethereum-optimism/op-geth/issues/542)
         (#BaseMainnet(#BlockPi), ?"eth_feeHistory"), // Temporary issue with [op-geth](https://github.com/ethereum-optimism/op-geth/issues/542)
     ];

--- a/e2e/motoko/main.mo
+++ b/e2e/motoko/main.mo
@@ -28,6 +28,8 @@ shared ({ caller = installer }) actor class Main() {
         (#EthMainnet(#Llama), ?"eth_sendRawTransaction"), // Non-standard error message
         (#ArbitrumOne(#Ankr), ?"eth_getLogs"), // Timeout expired
         (#BaseMainnet(#Llama), null), // No response (temporary issue)
+        (#OptimismMainnet(#BlockPi), ?"eth_feeHistory"), // Temporary issue with [op-geth](https://github.com/ethereum-optimism/op-geth/issues/542)
+        (#BaseMainnet(#BlockPi), ?"eth_feeHistory"), // Temporary issue with [op-geth](https://github.com/ethereum-optimism/op-geth/issues/542)
     ];
 
     func runTests(caller : Principal, category : TestCategory) : async () {

--- a/src/http.rs
+++ b/src/http.rs
@@ -14,7 +14,7 @@ use canhttp::{
         json::{
             HttpJsonRpcRequest, HttpJsonRpcResponse, Id, JsonRequestConversionError,
             JsonRequestConverter, JsonResponseConversionError, JsonResponseConverter,
-            JsonRpcRequestBody,
+            JsonRpcRequest,
         },
         FilterNonSuccessfulHttpResponse, FilterNonSuccessulHttpResponseError,
         HttpRequestConversionError, HttpRequestConverter, HttpResponseConversionError,
@@ -49,7 +49,7 @@ pub fn json_rpc_request_arg(
     json_rpc_payload: &str,
     max_response_bytes: u64,
 ) -> RpcResult<HttpJsonRpcRequest<serde_json::Value>> {
-    let body: JsonRpcRequestBody<serde_json::Value> = serde_json::from_str(json_rpc_payload)
+    let body: JsonRpcRequest<serde_json::Value> = serde_json::from_str(json_rpc_payload)
         .map_err(|e| {
             RpcError::ValidationError(ValidationError::Custom(format!(
                 "Invalid JSON RPC request: {e}"

--- a/src/http.rs
+++ b/src/http.rs
@@ -8,6 +8,7 @@ use crate::{
     types::{MetricRpcHost, MetricRpcMethod, ResolvedRpcService},
     util::canonicalize_json,
 };
+use canhttp::http::json::Id;
 use canhttp::{
     convert::ConvertRequestLayer,
     http::{
@@ -90,7 +91,7 @@ where
                     let req_data = MetricData {
                         method: rpc_method.clone(),
                         host: MetricRpcHost(req.uri().host().unwrap().to_string()),
-                        request_id: req.body().id().cloned(),
+                        request_id: req.body().id().clone(),
                     };
                     add_metric_entry!(
                         requests,
@@ -103,7 +104,7 @@ where
                     observe_response(req_data.method, req_data.host, response.status().as_u16());
                     log!(
                         TRACE_HTTP,
-                        "Got response for request with id `{:?}`. Response with status {}: {:?}",
+                        "Got response for request with id `{}`. Response with status {}: {:?}",
                         req_data.request_id,
                         response.status(),
                         response.body()
@@ -128,7 +129,7 @@ where
                             );
                             log!(
                                 TRACE_HTTP,
-                                "Unsuccessful HTTP response for request with id `{:?}`. Response with status {}: {}",
+                                "Unsuccessful HTTP response for request with id `{}`. Response with status {}: {}",
                                 req_data.request_id,
                                 response.status(),
                                 String::from_utf8_lossy(response.body())
@@ -144,7 +145,7 @@ where
                             observe_response(req_data.method, req_data.host, *status);
                             log!(
                                 TRACE_HTTP,
-                                "Invalid JSON RPC response for request with id `{:?}`: {}",
+                                "Invalid JSON RPC response for request with id `{}`: {}",
                                 req_data.request_id,
                                 error
                             );
@@ -289,7 +290,7 @@ impl From<HttpClientError> for RpcError {
 struct MetricData {
     method: MetricRpcMethod,
     host: MetricRpcHost,
-    request_id: Option<serde_json::Value>,
+    request_id: Id,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/src/http.rs
+++ b/src/http.rs
@@ -16,7 +16,7 @@ use canhttp::{
             JsonRequestConverter, JsonResponseConversionError, JsonResponseConverter,
             JsonRpcRequest,
         },
-        FilterNonSuccessfulHttpResponse, FilterNonSuccessulHttpResponseError,
+        FilterNonSuccessfulHttpResponse, FilterNonSuccessfulHttpResponseError,
         HttpRequestConversionError, HttpRequestConverter, HttpResponseConversionError,
         HttpResponseConverter,
     },
@@ -136,7 +136,7 @@ where
                             );
                         }
                         HttpClientError::UnsuccessfulHttpResponse(
-                            FilterNonSuccessulHttpResponseError::UnsuccessfulResponse(response),
+                            FilterNonSuccessfulHttpResponseError::UnsuccessfulResponse(response),
                         ) => {
                             observe_response(
                                 req_data.method,
@@ -227,7 +227,7 @@ pub enum HttpClientError {
     #[error("cycles accounting error: {0}")]
     CyclesAccountingError(CyclesAccountingError),
     #[error("HTTP response was not successful: {0}")]
-    UnsuccessfulHttpResponse(FilterNonSuccessulHttpResponseError<Vec<u8>>),
+    UnsuccessfulHttpResponse(FilterNonSuccessfulHttpResponseError<Vec<u8>>),
     #[error("Error converting response to JSON: {0}")]
     InvalidJsonResponse(JsonResponseConversionError),
 }
@@ -245,8 +245,8 @@ impl From<HttpResponseConversionError> for HttpClientError {
     }
 }
 
-impl From<FilterNonSuccessulHttpResponseError<Vec<u8>>> for HttpClientError {
-    fn from(value: FilterNonSuccessulHttpResponseError<Vec<u8>>) -> Self {
+impl From<FilterNonSuccessfulHttpResponseError<Vec<u8>>> for HttpClientError {
+    fn from(value: FilterNonSuccessfulHttpResponseError<Vec<u8>>) -> Self {
         HttpClientError::UnsuccessfulHttpResponse(value)
     }
 }
@@ -299,7 +299,7 @@ impl From<HttpClientError> for RpcError {
                 parsing_error: Some(parsing_error),
             }),
             HttpClientError::UnsuccessfulHttpResponse(
-                FilterNonSuccessulHttpResponseError::UnsuccessfulResponse(response),
+                FilterNonSuccessfulHttpResponseError::UnsuccessfulResponse(response),
             ) => RpcError::HttpOutcallError(HttpOutcallError::InvalidHttpJsonRpcResponse {
                 status: response.status().as_u16(),
                 body: String::from_utf8_lossy(response.body()).to_string(),

--- a/src/http.rs
+++ b/src/http.rs
@@ -49,8 +49,8 @@ pub fn json_rpc_request_arg(
     json_rpc_payload: &str,
     max_response_bytes: u64,
 ) -> RpcResult<HttpJsonRpcRequest<serde_json::Value>> {
-    let body: JsonRpcRequest<serde_json::Value> = serde_json::from_str(json_rpc_payload)
-        .map_err(|e| {
+    let body: JsonRpcRequest<serde_json::Value> =
+        serde_json::from_str(json_rpc_payload).map_err(|e| {
             RpcError::ValidationError(ValidationError::Custom(format!(
                 "Invalid JSON RPC request: {e}"
             )))
@@ -84,7 +84,7 @@ pub fn http_client<I, O>(
     retry: bool,
 ) -> impl Service<HttpJsonRpcRequest<I>, Response = HttpJsonRpcResponse<O>, Error = RpcError>
 where
-    I: Serialize + Clone,
+    I: Serialize + Clone + Debug,
     O: DeserializeOwned + Debug,
 {
     let maybe_retry = if retry {
@@ -113,6 +113,11 @@ where
                         requests,
                         (req_data.method.clone(), req_data.host.clone()),
                         1
+                    );
+                    log!(TRACE_HTTP, "JSON-RPC request with id `{}` to {}: {:?}",
+                        req_data.request_id,
+                        req_data.host.0,
+                        req.body()
                     );
                     req_data
                 })

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,5 +1,6 @@
 use crate::types::{ApiKey, LogFilter, Metrics, OverrideProvider, ProviderId};
 use candid::Principal;
+use canhttp::http::json::Id;
 use ic_stable_structures::memory_manager::VirtualMemory;
 use ic_stable_structures::{
     memory_manager::{MemoryId, MemoryManager},
@@ -103,13 +104,13 @@ pub fn set_override_provider(provider: OverrideProvider) {
     });
 }
 
-pub fn next_request_id() -> u64 {
+pub fn next_request_id() -> Id {
     UNSTABLE_HTTP_REQUEST_COUNTER.with_borrow_mut(|counter| {
         let current_request_id = *counter;
         // overflow is not an issue here because we only use `next_request_id` to correlate
         // requests and responses in logs.
         *counter = counter.wrapping_add(1);
-        current_request_id
+        Id::from(current_request_id)
     })
 }
 

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -10,8 +10,7 @@ use crate::rpc_client::numeric::{TransactionCount, Wei};
 use crate::types::MetricRpcMethod;
 use candid::candid_method;
 use canhttp::{
-    http::json::JsonRpcRequestBody,
-    json::{JsonRpcRequestBody, JsonRpcResponseBody},
+    http::json::{JsonRpcRequestBody, JsonRpcResponseBody},
     MaxResponseBytesRequestExtension, TransformContextRequestExtension,
 };
 use evm_rpc_types::{JsonRpcError, RpcError, RpcService};

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -10,7 +10,7 @@ use crate::rpc_client::numeric::{TransactionCount, Wei};
 use crate::types::MetricRpcMethod;
 use candid::candid_method;
 use canhttp::{
-    http::json::{JsonRpcRequestBody, JsonRpcResponseBody},
+    http::json::{JsonRpcRequest, JsonRpcResponseBody},
     MaxResponseBytesRequestExtension, TransformContextRequestExtension,
 };
 use evm_rpc_types::{JsonRpcError, RpcError, RpcService};
@@ -180,7 +180,7 @@ where
             "cleanup_response".to_owned(),
             transform_op.clone(),
         ))
-        .body(JsonRpcRequestBody::new(method, params))
+        .body(JsonRpcRequest::new(method, params))
         .expect("BUG: invalid request");
 
     let eth_method = request.body().method().to_string();

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -10,7 +10,7 @@ use crate::rpc_client::numeric::{TransactionCount, Wei};
 use crate::types::MetricRpcMethod;
 use candid::candid_method;
 use canhttp::{
-    http::json::{JsonRpcRequest, JsonRpcResponseBody},
+    http::json::{JsonRpcRequest, JsonRpcResponse},
     MaxResponseBytesRequestExtension, TransformContextRequestExtension,
 };
 use evm_rpc_types::{JsonRpcError, RpcError, RpcService};
@@ -62,7 +62,7 @@ impl ResponseTransform {
         where
             T: Serialize + DeserializeOwned,
         {
-            let response: JsonRpcResponseBody<T> = match serde_json::from_slice(body) {
+            let response: JsonRpcResponse<T> = match serde_json::from_slice(body) {
                 Ok(response) => response,
                 Err(_) => return,
             };
@@ -75,7 +75,7 @@ impl ResponseTransform {
         where
             T: Serialize + DeserializeOwned,
         {
-            let mut response: JsonRpcResponseBody<Vec<T>> = match serde_json::from_slice(body) {
+            let mut response: JsonRpcResponse<Vec<T>> = match serde_json::from_slice(body) {
                 Ok(response) => response,
                 Err(_) => return,
             };

--- a/src/rpc_client/eth_rpc/mod.rs
+++ b/src/rpc_client/eth_rpc/mod.rs
@@ -6,14 +6,14 @@ use crate::logs::{DEBUG, TRACE_HTTP};
 use crate::memory::{get_override_provider, next_request_id};
 use crate::providers::resolve_rpc_service;
 use crate::rpc_client::eth_rpc_error::{sanitize_send_raw_transaction_result, Parser};
-use crate::rpc_client::json::responses::{
-    Block, FeeHistory, JsonRpcReply, JsonRpcResult, LogEntry, TransactionReceipt,
-};
+use crate::rpc_client::json::responses::{Block, FeeHistory, LogEntry, TransactionReceipt};
 use crate::rpc_client::numeric::{TransactionCount, Wei};
 use crate::types::MetricRpcMethod;
 use candid::candid_method;
-use canhttp::http::json::JsonRpcRequestBody;
-use canhttp::http::{MaxResponseBytesRequestExtension, TransformContextRequestExtension};
+use canhttp::http::{
+    json::{JsonRpcRequestBody, JsonRpcResponseBody, JsonRpcResult},
+    MaxResponseBytesRequestExtension, TransformContextRequestExtension,
+};
 use evm_rpc_types::{HttpOutcallError, JsonRpcError, RpcError, RpcService};
 use ic_canister_log::log;
 use ic_cdk::api::call::RejectionCode;
@@ -65,7 +65,7 @@ impl ResponseTransform {
         where
             T: Serialize + DeserializeOwned,
         {
-            let response: JsonRpcReply<T> = match serde_json::from_slice(body) {
+            let response: JsonRpcResponseBody<T> = match serde_json::from_slice(body) {
                 Ok(response) => response,
                 Err(_) => return,
             };
@@ -78,7 +78,7 @@ impl ResponseTransform {
         where
             T: Serialize + DeserializeOwned,
         {
-            let mut response: JsonRpcReply<Vec<T>> = match serde_json::from_slice(body) {
+            let mut response: JsonRpcResponseBody<Vec<T>> = match serde_json::from_slice(body) {
                 Ok(response) => response,
                 Err(_) => return,
             };

--- a/src/rpc_client/eth_rpc_error/mod.rs
+++ b/src/rpc_client/eth_rpc_error/mod.rs
@@ -1,7 +1,7 @@
 use crate::logs::DEBUG;
 use crate::rpc_client::json::responses::SendRawTransactionResult;
 use crate::rpc_client::json::Hash;
-use canhttp::http::json::{JsonRpcError, JsonRpcResponseBody};
+use canhttp::http::json::{JsonRpcError, JsonRpcResponse};
 use ic_canister_log::log;
 
 #[cfg(test)]
@@ -181,7 +181,7 @@ impl ErrorParser for Parser {
 /// queried by HTTP outcalls and the fact that `eth_sendRawTransaction` is not idempotent.
 /// The type `JsonRpcReply<Hash>` of the original response is transformed into `JsonRpcReply<SendRawTxResult>`.
 pub fn sanitize_send_raw_transaction_result<T: ErrorParser>(body_bytes: &mut Vec<u8>, parser: T) {
-    let response: JsonRpcResponseBody<Hash> = match serde_json::from_slice(body_bytes) {
+    let response: JsonRpcResponse<Hash> = match serde_json::from_slice(body_bytes) {
         Ok(response) => response,
         Err(e) => {
             log!(DEBUG, "Error deserializing: {:?}", e);
@@ -221,8 +221,8 @@ pub fn sanitize_send_raw_transaction_result<T: ErrorParser>(body_bytes: &mut Vec
             }
         }
     };
-    let sanitized_reply: JsonRpcResponseBody<SendRawTransactionResult> =
-        JsonRpcResponseBody::from_parts(id, sanitized_result);
+    let sanitized_reply: JsonRpcResponse<SendRawTransactionResult> =
+        JsonRpcResponse::from_parts(id, sanitized_result);
 
     *body_bytes = serde_json::to_string(&sanitized_reply)
         .expect("BUG: failed to serialize error response")

--- a/src/rpc_client/eth_rpc_error/mod.rs
+++ b/src/rpc_client/eth_rpc_error/mod.rs
@@ -1,7 +1,8 @@
 use crate::logs::DEBUG;
-use crate::rpc_client::json::responses::{JsonRpcReply, JsonRpcResult, SendRawTransactionResult};
+use crate::rpc_client::json::responses::{SendRawTransactionResult};
 use crate::rpc_client::json::Hash;
 use ic_canister_log::log;
+use canhttp::http::json::{JsonRpcResult, JsonRpcResponseBody};
 
 #[cfg(test)]
 mod tests;
@@ -203,7 +204,7 @@ impl ErrorParser for Parser {
 /// queried by HTTP outcalls and the fact that `eth_sendRawTransaction` is not idempotent.
 /// The type `JsonRpcReply<Hash>` of the original response is transformed into `JsonRpcReply<SendRawTxResult>`.
 pub fn sanitize_send_raw_transaction_result<T: ErrorParser>(body_bytes: &mut Vec<u8>, parser: T) {
-    let response: JsonRpcReply<Hash> = match serde_json::from_slice(body_bytes) {
+    let response: JsonRpcResponseBody<Hash> = match serde_json::from_slice(body_bytes) {
         Ok(response) => response,
         Err(e) => {
             log!(DEBUG, "Error deserializing: {:?}", e);
@@ -236,7 +237,7 @@ pub fn sanitize_send_raw_transaction_result<T: ErrorParser>(body_bytes: &mut Vec
             }
         }
     };
-    let sanitized_reply: JsonRpcReply<SendRawTransactionResult> = JsonRpcReply {
+    let sanitized_reply: JsonRpcResponseBody<SendRawTransactionResult> = JsonRpcResponseBody {
         id: response.id,
         jsonrpc: response.jsonrpc,
         result: sanitized_result,

--- a/src/rpc_client/eth_rpc_error/mod.rs
+++ b/src/rpc_client/eth_rpc_error/mod.rs
@@ -1,8 +1,8 @@
 use crate::logs::DEBUG;
-use crate::rpc_client::json::responses::{SendRawTransactionResult};
+use crate::rpc_client::json::responses::SendRawTransactionResult;
 use crate::rpc_client::json::Hash;
+use canhttp::http::json::{JsonRpcResponseBody, JsonRpcResult};
 use ic_canister_log::log;
-use canhttp::http::json::{JsonRpcResult, JsonRpcResponseBody};
 
 #[cfg(test)]
 mod tests;

--- a/src/rpc_client/eth_rpc_error/mod.rs
+++ b/src/rpc_client/eth_rpc_error/mod.rs
@@ -29,29 +29,6 @@ pub enum SendRawTransactionError {
     NonceTooHigh,
 }
 
-// impl<T> From<SendRawTransactionError> for JsonRpcResult<T> {
-//     fn from(value: SendRawTransactionError) -> Self {
-//         match value {
-//             SendRawTransactionError::AlreadyKnown => JsonRpcResult::Error {
-//                 code: -32_000,
-//                 message: "Transaction already known".to_string(),
-//             },
-//             SendRawTransactionError::InsufficientFunds => JsonRpcResult::Error {
-//                 code: -32_000,
-//                 message: "insufficient funds for gas * price + value".to_string(),
-//             },
-//             SendRawTransactionError::NonceTooLow => JsonRpcResult::Error {
-//                 code: -32_000,
-//                 message: "nonce too low".to_string(),
-//             },
-//             SendRawTransactionError::NonceTooHigh => JsonRpcResult::Error {
-//                 code: -32_000,
-//                 message: "nonce too high".to_string(),
-//             },
-//         }
-//     }
-// }
-
 pub trait ErrorParser {
     fn try_parse_send_raw_transaction_error(
         &self,

--- a/src/rpc_client/eth_rpc_error/tests.rs
+++ b/src/rpc_client/eth_rpc_error/tests.rs
@@ -50,14 +50,9 @@ fn check_sanitize_send_raw_transaction_result<T: AsRef<[u8]>>(
     expected: T,
 ) {
     sanitize_send_raw_transaction_result(raw_response, Parser::new());
-    let expected_bytes = expected.as_ref();
-    assert_eq!(
-        raw_response,
-        expected_bytes,
-        "{:?} != {:?}",
-        String::from_utf8_lossy(raw_response),
-        String::from_utf8_lossy(expected_bytes)
-    );
+    let sanitized_response: serde_json::Value = serde_json::from_slice(raw_response).unwrap();
+    let expected_response: serde_json::Value = serde_json::from_slice(expected.as_ref()).unwrap();
+    assert_eq!(sanitized_response, expected_response,);
 }
 
 fn sanitized_ok_response() -> Vec<u8> {

--- a/src/rpc_client/json/responses.rs
+++ b/src/rpc_client/json/responses.rs
@@ -5,7 +5,6 @@ use crate::rpc_client::numeric::{
     TransactionIndex, Wei, WeiPerGas,
 };
 use candid::Deserialize;
-use evm_rpc_types::{JsonRpcError, RpcError};
 use ic_ethereum_types::Address;
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
@@ -313,43 +312,5 @@ impl From<Vec<u8>> for Data {
 impl AsRef<[u8]> for Data {
     fn as_ref(&self) -> &[u8] {
         &self.0
-    }
-}
-
-//TODO XC-287: remove this type to use the corresponding ones from canhttp
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct JsonRpcReply<T> {
-    pub id: u64,
-    pub jsonrpc: String,
-    #[serde(flatten)]
-    pub result: JsonRpcResult<T>,
-}
-
-/// An envelope for all JSON-RPC replies.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum JsonRpcResult<T> {
-    #[serde(rename = "result")]
-    Result(T),
-    #[serde(rename = "error")]
-    Error { code: i64, message: String },
-}
-
-impl<T> JsonRpcResult<T> {
-    pub fn unwrap(self) -> T {
-        match self {
-            Self::Result(t) => t,
-            Self::Error { code, message } => panic!(
-                "expected JSON RPC call to succeed, got an error: error_code = {code}, message = {message}"
-            ),
-        }
-    }
-}
-
-impl<T> From<JsonRpcResult<T>> for Result<T, RpcError> {
-    fn from(result: JsonRpcResult<T>) -> Self {
-        match result {
-            JsonRpcResult::Result(r) => Ok(r),
-            JsonRpcResult::Error { code, message } => Err(JsonRpcError { code, message }.into()),
-        }
     }
 }

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -472,12 +472,7 @@ impl<T> MultiCallResults<T> {
 
     #[cfg(test)]
     fn from_json_rpc_result<
-        I: IntoIterator<
-            Item = (
-                RpcService,
-                Result<canhttp::http::json::JsonRpcResult<T>, RpcError>,
-            ),
-        >,
+        I: IntoIterator<Item = (RpcService, canhttp::http::json::JsonRpcResult<T>)>,
     >(
         iter: I,
     ) -> Self {
@@ -485,16 +480,15 @@ impl<T> MultiCallResults<T> {
             (
                 provider,
                 match result {
-                    Ok(json_rpc_result) => match json_rpc_result {
-                        canhttp::http::json::JsonRpcResult::Result(value) => Ok(value),
-                        canhttp::http::json::JsonRpcResult::Error { code, message } => {
-                            Err(RpcError::JsonRpcError(evm_rpc_types::JsonRpcError {
-                                code,
-                                message,
-                            }))
-                        }
-                    },
-                    Err(e) => Err(e),
+                    Ok(value) => Ok(value),
+                    Err(canhttp::http::json::JsonRpcError {
+                        code,
+                        message,
+                        data: _,
+                    }) => Err(RpcError::JsonRpcError(evm_rpc_types::JsonRpcError {
+                        code,
+                        message,
+                    })),
                 },
             )
         }))

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -475,7 +475,7 @@ impl<T> MultiCallResults<T> {
         I: IntoIterator<
             Item = (
                 RpcService,
-                Result<json::responses::JsonRpcResult<T>, RpcError>,
+                Result<canhttp::http::json::JsonRpcResult<T>, RpcError>,
             ),
         >,
     >(
@@ -486,8 +486,8 @@ impl<T> MultiCallResults<T> {
                 provider,
                 match result {
                     Ok(json_rpc_result) => match json_rpc_result {
-                        json::responses::JsonRpcResult::Result(value) => Ok(value),
-                        json::responses::JsonRpcResult::Error { code, message } => {
+                        canhttp::http::json::JsonRpcResult::Result(value) => Ok(value),
+                        canhttp::http::json::JsonRpcResult::Error { code, message } => {
                             Err(RpcError::JsonRpcError(evm_rpc_types::JsonRpcError {
                                 code,
                                 message,

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -71,9 +71,9 @@ mod multi_call_results {
     mod reduce_with_equality {
         use crate::rpc_client::tests::multi_call_results::{ANKR, PUBLIC_NODE};
         use crate::rpc_client::{MultiCallError, MultiCallResults};
+        use canhttp::http::json::JsonRpcResult;
         use evm_rpc_types::{HttpOutcallError, JsonRpcError, RpcError};
         use ic_cdk::api::call::RejectionCode;
-        use canhttp::http::json::JsonRpcResult;
 
         #[test]
         #[should_panic(expected = "MultiCallResults cannot be empty")]

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -69,11 +69,11 @@ mod multi_call_results {
     const CLOUDFLARE: RpcService = RpcService::EthMainnet(EthMainnetService::Cloudflare);
 
     mod reduce_with_equality {
-        use crate::rpc_client::json::responses::JsonRpcResult;
         use crate::rpc_client::tests::multi_call_results::{ANKR, PUBLIC_NODE};
         use crate::rpc_client::{MultiCallError, MultiCallResults};
         use evm_rpc_types::{HttpOutcallError, JsonRpcError, RpcError};
         use ic_cdk::api::call::RejectionCode;
+        use canhttp::http::json::JsonRpcResult;
 
         #[test]
         #[should_panic(expected = "MultiCallResults cannot be empty")]

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -71,7 +71,6 @@ mod multi_call_results {
     mod reduce_with_equality {
         use crate::rpc_client::tests::multi_call_results::{ANKR, PUBLIC_NODE};
         use crate::rpc_client::{MultiCallError, MultiCallResults};
-        use canhttp::http::json::JsonRpcResult;
         use evm_rpc_types::{HttpOutcallError, JsonRpcError, RpcError};
         use ic_cdk::api::call::RejectionCode;
 
@@ -110,17 +109,17 @@ mod multi_call_results {
             let results: MultiCallResults<String> = MultiCallResults::from_json_rpc_result(vec![
                 (
                     ANKR,
-                    Ok(JsonRpcResult::Error {
-                        code: -32700,
-                        message: "insufficient funds for gas * price + value".to_string(),
-                    }),
+                    Err(canhttp::http::json::JsonRpcError::new(
+                        -32700,
+                        "insufficient funds for gas * price + value",
+                    )),
                 ),
                 (
                     PUBLIC_NODE,
-                    Ok(JsonRpcResult::Error {
-                        code: -32000,
-                        message: "nonce too low".to_string(),
-                    }),
+                    Err(canhttp::http::json::JsonRpcError::new(
+                        -32000,
+                        "nonce too low",
+                    )),
                 ),
             ]);
 
@@ -132,8 +131,8 @@ mod multi_call_results {
         #[test]
         fn should_be_inconsistent_when_different_ok_results() {
             let results: MultiCallResults<String> = MultiCallResults::from_json_rpc_result(vec![
-                (ANKR, Ok(JsonRpcResult::Result("hello".to_string()))),
-                (PUBLIC_NODE, Ok(JsonRpcResult::Result("world".to_string()))),
+                (ANKR, Ok("hello".to_string())),
+                (PUBLIC_NODE, Ok("world".to_string())),
             ]);
 
             let reduced = results.clone().reduce_with_equality();
@@ -178,17 +177,17 @@ mod multi_call_results {
             let results: MultiCallResults<String> = MultiCallResults::from_json_rpc_result(vec![
                 (
                     ANKR,
-                    Ok(JsonRpcResult::Error {
-                        code: -32700,
-                        message: "insufficient funds for gas * price + value".to_string(),
-                    }),
+                    Err(canhttp::http::json::JsonRpcError::new(
+                        -32700,
+                        "insufficient funds for gas * price + value",
+                    )),
                 ),
                 (
                     PUBLIC_NODE,
-                    Ok(JsonRpcResult::Error {
-                        code: -32700,
-                        message: "insufficient funds for gas * price + value".to_string(),
-                    }),
+                    Err(canhttp::http::json::JsonRpcError::new(
+                        -32700,
+                        "insufficient funds for gas * price + value",
+                    )),
                 ),
             ]);
 
@@ -208,8 +207,8 @@ mod multi_call_results {
         #[test]
         fn should_be_consistent_ok_result() {
             let results: MultiCallResults<String> = MultiCallResults::from_json_rpc_result(vec![
-                (ANKR, Ok(JsonRpcResult::Result("0x01".to_string()))),
-                (PUBLIC_NODE, Ok(JsonRpcResult::Result("0x01".to_string()))),
+                (ANKR, Ok("0x01".to_string())),
+                (PUBLIC_NODE, Ok("0x01".to_string())),
             ]);
 
             let reduced = results.clone().reduce_with_equality();


### PR DESCRIPTION
Refactor the JSON-RPC request and response types to follow the [specification](https://www.jsonrpc.org/specification) more closely:

1. `jsonrpc` must have the value `"2.0"`.
2. `id` must be a String, a number or a null value.

Left for a future PR: it should be ensured that the response ID matches the one from the request. This will be added as another tower middleware.