### PR TITLE
feat: add map method to `JsonRpcResponse`

### DIFF
--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -152,6 +152,14 @@ impl<T> JsonRpcResponse<T> {
     pub fn id(&self) -> &Id {
         &self.id
     }
+
+    /// Map this response's result by the given function.
+    fn map(self, f: fn(T) -> T) -> Self {
+        Self {
+            result: self.result.map(f),
+            ..self
+        }
+    }
 }
 
 /// An envelope for all JSON-RPC responses.
@@ -184,6 +192,13 @@ impl<T> JsonRpcResultEnvelope<T> {
         match self {
             JsonRpcResultEnvelope::Ok(result) => Ok(result),
             JsonRpcResultEnvelope::Err(error) => Err(error),
+        }
+    }
+
+    fn map(self, f: fn(T) -> T) -> Self {
+        match self {
+            JsonRpcResultEnvelope::Ok(result) => JsonRpcResultEnvelope::Ok(f(result)),
+            JsonRpcResultEnvelope::Err(error) => JsonRpcResultEnvelope::Err(error),
         }
     }
 }

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -195,7 +195,7 @@ impl<T> JsonRpcResultEnvelope<T> {
         }
     }
 
-    fn map(self, f: fn(T) -> T) -> Self {
+    fn map(self, f: impl FnOnce(T) -> T) -> Self {
         match self {
             JsonRpcResultEnvelope::Ok(result) => JsonRpcResultEnvelope::Ok(f(result)),
             JsonRpcResultEnvelope::Err(error) => JsonRpcResultEnvelope::Err(error),

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -154,8 +154,7 @@ impl<T> JsonRpcResponse<T> {
     }
 
     /// Map this response's result by the given function.
-    #[allow(dead_code)]
-    fn map(self, f: fn(T) -> T) -> Self {
+    pub fn map(self, f: fn(T) -> T) -> Self {
         Self {
             result: self.result.map(f),
             ..self
@@ -196,7 +195,6 @@ impl<T> JsonRpcResultEnvelope<T> {
         }
     }
 
-    #[allow(dead_code)]
     fn map(self, f: fn(T) -> T) -> Self {
         match self {
             JsonRpcResultEnvelope::Ok(result) => JsonRpcResultEnvelope::Ok(f(result)),

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -154,6 +154,7 @@ impl<T> JsonRpcResponse<T> {
     }
 
     /// Map this response's result by the given function.
+    #[allow(dead_code)]
     fn map(self, f: fn(T) -> T) -> Self {
         Self {
             result: self.result.map(f),
@@ -195,6 +196,7 @@ impl<T> JsonRpcResultEnvelope<T> {
         }
     }
 
+    #[allow(dead_code)]
     fn map(self, f: fn(T) -> T) -> Self {
         match self {
             JsonRpcResultEnvelope::Ok(result) => JsonRpcResultEnvelope::Ok(f(result)),

--- a/canhttp/src/http/json/response.rs
+++ b/canhttp/src/http/json/response.rs
@@ -154,7 +154,7 @@ impl<T> JsonRpcResponse<T> {
     }
 
     /// Map this response's result by the given function.
-    pub fn map(self, f: fn(T) -> T) -> Self {
+    pub fn map(self, f: impl FnOnce(T) -> T) -> Self {
         Self {
             result: self.result.map(f),
             ..self

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -93,6 +93,16 @@ mod json_rpc {
             assert_matches!(serde_json::from_value::<Version>(version), Err(_));
         }
     }
+
+    #[test]
+    fn should_map_json_rpc_response() {
+        let response = JsonRpcResponse::from_ok(Id::Number(0), 0);
+
+        assert_eq!(
+            response.map(|value| value + 1),
+            JsonRpcResponse::from_ok(Id::Number(0), 1)
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Add a `map` method to `canhttp::http::json::response::JsonRpcResponse`.