### PR TITLE
feat(canhttp): JSON-RPC request ID with constant binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "maplit",
  "num-traits",
  "pin-project",
+ "proptest",
  "serde",
  "serde_json",
  "sha2",

--- a/canhttp/Cargo.toml
+++ b/canhttp/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = { workspace = true }
 candid = { workspace = true }
 itertools = { workspace = true }
 maplit = { workspace = true }
+proptest = {workspace = true}
 tokio = { workspace = true, features = ["full"] }
 
 [features]

--- a/canhttp/src/http/json/id.rs
+++ b/canhttp/src/http/json/id.rs
@@ -47,3 +47,83 @@ impl Display for Id {
         }
     }
 }
+
+/// An identifier that uses the same number of bytes when serialized to JSON.
+///
+/// Having the same number of bytes for JSON-RPC request IDs ensures that
+/// two JSON-RPC requests only differing by their IDs will have the same number of bytes once serialized.
+/// Since the number of bytes of a serialized JSON-RPC request directly influences the
+/// cycles cost of an HTTP outcall, two requests only differing by their IDs will therefore require the same amount of cycles,
+/// which helps applications in estimating the cycle cost of their requests.
+///
+/// # Examples
+///
+/// ```rust
+/// use canhttp::http::json::{ConstantSizeId, JsonRpcRequest};
+///
+/// let request_1 = JsonRpcRequest::new("getVersion", serde_json::Value::Null).with_id(ConstantSizeId::ZERO);
+/// let request_2 = JsonRpcRequest::new("getVersion", serde_json::Value::Null).with_id(ConstantSizeId::MAX);
+///
+/// assert_eq!(
+///     serde_json::to_vec(&request_1).unwrap().len(),
+///     serde_json::to_vec(&request_2).unwrap().len()
+/// );
+/// ```
+#[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ConstantSizeId(u64);
+
+impl<T: Into<u64>> From<T> for ConstantSizeId {
+    fn from(value: T) -> Self {
+        Self(value.into())
+    }
+}
+
+impl Display for ConstantSizeId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.to_constant_size_string(), f)
+    }
+}
+
+impl ConstantSizeId {
+    /// Zero numeric ID.
+    pub const ZERO: ConstantSizeId = ConstantSizeId(0);
+    /// Largest ID.
+    pub const MAX: ConstantSizeId = ConstantSizeId(u64::MAX);
+
+    /// Increment the current value and return the previous value.
+    ///
+    /// If the maximum ID is reached, the next value will be wrapped to [`Self::ZERO`].
+    /// This method never panics.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use canhttp::http::json::ConstantSizeId;
+    ///
+    /// let mut id = ConstantSizeId::ZERO;
+    /// assert_eq!(id.get_and_increment(), 0_u64.into());
+    /// assert_eq!(id.get_and_increment(), 1_u64.into());
+    /// assert_eq!(id.get_and_increment(), 2_u64.into());
+    ///
+    /// let mut id = ConstantSizeId::MAX;
+    /// assert_eq!(id.get_and_increment(), u64::MAX.into());
+    /// assert_eq!(id.get_and_increment(), 0_u64.into());
+    /// ```
+    pub fn get_and_increment(&mut self) -> ConstantSizeId {
+        let previous = self.0;
+        self.0 = self.0.wrapping_add(1);
+        ConstantSizeId::from(previous)
+    }
+
+    fn to_constant_size_string(&self) -> String {
+        // Need at most 20 decimal characters to represent a u64:
+        // 19 < log_10(u64::MAX) < 20
+        format!("{:0<20}", self.0)
+    }
+}
+
+impl From<ConstantSizeId> for Id {
+    fn from(value: ConstantSizeId) -> Self {
+        Id::String(value.to_string())
+    }
+}

--- a/canhttp/src/http/json/id.rs
+++ b/canhttp/src/http/json/id.rs
@@ -118,7 +118,7 @@ impl ConstantSizeId {
     fn to_constant_size_string(&self) -> String {
         // Need at most 20 decimal characters to represent a u64:
         // 19 < log_10(u64::MAX) < 20
-        format!("{:0<20}", self.0)
+        format!("{:0>20}", self.0)
     }
 }
 

--- a/canhttp/src/http/json/id.rs
+++ b/canhttp/src/http/json/id.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+use std::num::ParseIntError;
+use std::str::FromStr;
 
 /// An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
 ///
@@ -125,5 +127,17 @@ impl ConstantSizeId {
 impl From<ConstantSizeId> for Id {
     fn from(value: ConstantSizeId) -> Self {
         Id::String(value.to_string())
+    }
+}
+
+impl FromStr for ConstantSizeId {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let num = match s.find(|c| c != '0') {
+            Some(non_zero_index) => s[non_zero_index..].parse::<u64>(),
+            None => s.parse::<u64>(),
+        };
+        num.map(ConstantSizeId::from)
     }
 }

--- a/canhttp/src/http/json/mod.rs
+++ b/canhttp/src/http/json/mod.rs
@@ -50,7 +50,7 @@
 //! # }
 
 use crate::convert::{ConvertRequest, ConvertRequestLayer, ConvertResponse, ConvertResponseLayer};
-pub use id::Id;
+pub use id::{ConstantSizeId, Id};
 pub use request::{
     HttpJsonRpcRequest, JsonRequestConversionError, JsonRequestConverter, JsonRpcRequest,
 };

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -85,7 +85,7 @@ fn add_content_type_header_if_missing(mut request: HttpRequest) -> HttpRequest {
 pub type HttpJsonRpcRequest<T> = http::Request<JsonRpcRequest<T>>;
 
 /// Body for all JSON-RPC requests, see the [specification](https://www.jsonrpc.org/specification).
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct JsonRpcRequest<T> {
     jsonrpc: Version,
     method: String,

--- a/canhttp/src/http/json/request.rs
+++ b/canhttp/src/http/json/request.rs
@@ -1,5 +1,5 @@
 use crate::convert::Convert;
-use crate::http::json::{Id, Version};
+use crate::http::json::{ConstantSizeId, Id, Version};
 use crate::http::HttpRequest;
 use http::header::CONTENT_TYPE;
 use http::HeaderValue;
@@ -95,18 +95,23 @@ pub struct JsonRpcRequest<T> {
 
 impl<T> JsonRpcRequest<T> {
     /// Create a new body of a JSON-RPC request.
+    ///
+    /// By default, constant-size ID is used. See [`ConstantSizeId`].
     pub fn new(method: impl Into<String>, params: T) -> Self {
         Self {
             jsonrpc: Version::V2,
             method: method.into(),
-            id: Id::ZERO,
+            id: ConstantSizeId::ZERO.into(),
             params: Some(params),
         }
     }
 
     /// Change the request ID following the builder pattern.
-    pub fn with_id(self, id: Id) -> Self {
-        Self { id, ..self }
+    pub fn with_id<I: Into<Id>>(self, id: I) -> Self {
+        Self {
+            id: id.into(),
+            ..self
+        }
     }
 
     /// Change the request ID.

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -133,6 +133,16 @@ mod constant_size_id {
             let bytes = serde_json::to_vec(&id).unwrap();
             prop_assert_eq!(bytes.len(), 22);
         }
+
+        #[test]
+        fn should_parse_string_value_and_ignore_extra_padding(id in any::<u64>(), extra_padding_len in any::<u8>()) {
+            let id = ConstantSizeId::from(id);
+            let s = id.to_string();
+            prop_assert_eq!(id.clone(), s.parse().unwrap());
+
+            let padded = format!("{}{}", "0".repeat(extra_padding_len as usize), s);
+            prop_assert_eq!(id, padded.parse().unwrap());
+        }
     }
 }
 

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -117,7 +117,7 @@ mod constant_size_id {
     }
 
     #[test]
-    fn should_have_necessary_padding() {
+    fn should_have_only_necessary_padding() {
         let zero = ConstantSizeId::ZERO.to_string();
         let max = ConstantSizeId::MAX.to_string();
         assert_eq!(zero.len(), max.len());

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -105,6 +105,31 @@ mod json_rpc {
     }
 }
 
+mod constant_size_id {
+    use crate::http::json::{ConstantSizeId, Id};
+    use proptest::prelude::any;
+    use proptest::{prop_assert_eq, proptest};
+
+    #[test]
+    fn should_have_necessary_padding() {
+        let zero = ConstantSizeId::ZERO.to_string();
+        let max = ConstantSizeId::MAX.to_string();
+        assert_eq!(zero.len(), max.len());
+
+        let u64_max = u64::MAX.to_string();
+        assert_eq!(u64_max, max);
+    }
+
+    proptest! {
+        #[test]
+        fn should_have_constant_size_when_serialized(id in any::<u64>()) {
+            let id = Id::from(ConstantSizeId::from(id));
+            let bytes = serde_json::to_vec(&id).unwrap();
+            prop_assert_eq!(bytes.len(), 22);
+        }
+    }
+}
+
 #[tokio::test]
 async fn should_convert_json_request() {
     let url = "https://internetcomputer.org/";

--- a/canhttp/src/http/json/tests.rs
+++ b/canhttp/src/http/json/tests.rs
@@ -111,6 +111,12 @@ mod constant_size_id {
     use proptest::{prop_assert_eq, proptest};
 
     #[test]
+    fn should_add_padding_to_the_left() {
+        let one = ConstantSizeId::from(1_u8);
+        assert_eq!(one.to_string(), "00000000000000000001")
+    }
+
+    #[test]
     fn should_have_necessary_padding() {
         let zero = ConstantSizeId::ZERO.to_string();
         let max = ConstantSizeId::MAX.to_string();


### PR DESCRIPTION
Add a wrapper around a JSON-RPC request ID to ensure that the amount of bytes used when serialized to JSON is constant. 

This is necessary to ensure that two HTTPs outcalls for two JSON-RPC requests differing only by their IDs will have an identical cycle cost. See also dfinity/sol-rpc-canister#62.