### PR TITLE
chore: re-order default Sepolia providers

### DIFF
--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -81,9 +81,9 @@ impl Providers {
     ];
 
     const DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] = &[
+        EthSepoliaService::PublicNode,
         EthSepoliaService::Ankr,
         EthSepoliaService::BlockPi,
-        EthSepoliaService::PublicNode,
     ];
     const NON_DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] =
         &[EthSepoliaService::Alchemy, EthSepoliaService::Sepolia];


### PR DESCRIPTION
(XC-364) Since Ankr charges credits for RPC calls for Sepolia, move it down the list of default providers. Move PublicNode to the top spot since it is free. This means calls using a single provider will now make requests to PublicNode and hence avoid any credits being spent.