### PR TITLE
chore: re-order default Sepolia providers 

### DIFF
--- a/e2e/motoko/main.mo
+++ b/e2e/motoko/main.mo
@@ -26,7 +26,10 @@ shared ({ caller = installer }) actor class Main() {
     let ignoredTests = [
         (#EthMainnet(#BlockPi), ?"eth_sendRawTransaction"), // "Private transaction replacement (same nonce) with gas price change lower than 10% is not allowed within 30 sec from the previous transaction."
         (#EthMainnet(#Llama), ?"eth_sendRawTransaction"), // Non-standard error message
-        (#ArbitrumOne(#Ankr), ?"eth_getLogs"), // Timeout expired
+        (#ArbitrumOne(#Ankr), null), // Need API key
+        (#BaseMainnet(#Ankr), null), // Need API key
+        (#EthMainnet(#Ankr), null), // Need API key
+        (#OptimismMainnet(#Ankr), null), // Need API key
         (#BaseMainnet(#Llama), null), // No response (temporary issue)
     ];
 

--- a/e2e/rust/src/main.rs
+++ b/e2e/rust/src/main.rs
@@ -77,7 +77,7 @@ pub async fn test() {
         "eth_getBlockByNumber",
         (
             RpcServices::EthMainnet(Some(vec![
-                EthMainnetService::Ankr,
+                // EthMainnetService::Ankr, // Need API key
                 EthMainnetService::BlockPi,
                 EthMainnetService::Llama,
                 EthMainnetService::PublicNode,

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -72,9 +72,9 @@ impl Providers {
     ];
 
     const DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] = &[
+        EthSepoliaService::PublicNode,
         EthSepoliaService::Ankr,
         EthSepoliaService::BlockPi,
-        EthSepoliaService::PublicNode,
     ];
     const NON_DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] =
         &[EthSepoliaService::Alchemy, EthSepoliaService::Sepolia];


### PR DESCRIPTION
1. Cherry-pick #410 to move `PublicNode` as the first default provider for Ethereum Sepolia.
2. Cherry-pick #387 for `e2e/motoko/main.mo` and `e2e/rust/src/main.rs` to disable `Ankr` in end-to-end tests since an API key is required.