### PR TITLE
fix: replace Cloudflare with Ankr

### DIFF
--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -72,9 +72,9 @@ impl Providers {
     ];
 
     const DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] = &[
+        EthSepoliaService::PublicNode,
         EthSepoliaService::Ankr,
         EthSepoliaService::BlockPi,
-        EthSepoliaService::PublicNode,
     ];
     const NON_DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] =
         &[EthSepoliaService::Alchemy, EthSepoliaService::Sepolia];

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -62,13 +62,13 @@ impl Providers {
     // if the providers are not explicitly specified by the caller.
     const DEFAULT_ETH_MAINNET_SERVICES: &'static [EthMainnetService] = &[
         EthMainnetService::BlockPi,
-        EthMainnetService::Cloudflare,
+        EthMainnetService::Ankr,
         EthMainnetService::PublicNode,
     ];
     const NON_DEFAULT_ETH_MAINNET_SERVICES: &'static [EthMainnetService] = &[
         EthMainnetService::Llama,
         EthMainnetService::Alchemy,
-        EthMainnetService::Ankr,
+        EthMainnetService::Cloudflare,
     ];
 
     const DEFAULT_ETH_SEPOLIA_SERVICES: &'static [EthSepoliaService] = &[

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1078,7 +1078,7 @@ fn candid_rpc_should_err_with_insufficient_cycles() {
     assert_matches!(
         result.pop().unwrap(),
         (
-            RpcService::EthMainnet(EthMainnetService::Cloudflare),
+            RpcService::EthMainnet(EthMainnetService::PublicNode),
             Err(RpcError::HttpOutcallError(HttpOutcallError::IcError {
                 code: RejectionCode::CanisterReject,
                 message
@@ -1133,12 +1133,12 @@ fn candid_rpc_should_err_when_service_unavailable() {
         Metrics {
             requests: hashmap! {
                 (rpc_method(), BLOCKPI_ETH_HOSTNAME.into()) => 1,
-                (rpc_method(), CLOUDFLARE_HOSTNAME.into()) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
                 (rpc_method(), PUBLICNODE_ETH_MAINNET_HOSTNAME.into()) => 1,
             },
             responses: hashmap! {
                 (rpc_method(), BLOCKPI_ETH_HOSTNAME.into(), 503.into()) => 1,
-                (rpc_method(), CLOUDFLARE_HOSTNAME.into(), 503.into()) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into(), 503.into()) => 1,
                 (rpc_method(), PUBLICNODE_ETH_MAINNET_HOSTNAME.into(), 503.into()) => 1,
             },
             ..Default::default()
@@ -1458,18 +1458,18 @@ fn candid_rpc_should_return_inconsistent_results_with_consensus_error() {
         result,
         vec![
             (
-                RpcService::EthMainnet(EthMainnetService::PublicNode),
+                RpcService::EthMainnet(EthMainnetService::BlockPi),
                 Ok(1_u8.into())
             ),
             (
-                RpcService::EthMainnet(EthMainnetService::BlockPi),
+                RpcService::EthMainnet(EthMainnetService::Ankr),
                 Err(RpcError::HttpOutcallError(HttpOutcallError::IcError {
                     code: RejectionCode::SysTransient,
                     message: CONSENSUS_ERROR.to_string()
                 }))
             ),
             (
-                RpcService::EthMainnet(EthMainnetService::Cloudflare),
+                RpcService::EthMainnet(EthMainnetService::PublicNode),
                 Err(RpcError::HttpOutcallError(HttpOutcallError::IcError {
                     code: RejectionCode::SysTransient,
                     message: CONSENSUS_ERROR.to_string()
@@ -1483,8 +1483,8 @@ fn candid_rpc_should_return_inconsistent_results_with_consensus_error() {
     assert_eq!(
         err_http_outcall,
         hashmap! {
-            (rpc_method(), BLOCKPI_ETH_HOSTNAME.into(), RejectionCode::SysTransient) => 1,
-            (rpc_method(), CLOUDFLARE_HOSTNAME.into(), RejectionCode::SysTransient) => 1,
+            (rpc_method(), ANKR_HOSTNAME.into(), RejectionCode::SysTransient) => 1,
+            (rpc_method(), PUBLICNODE_ETH_MAINNET_HOSTNAME.into(), RejectionCode::SysTransient) => 1,
         },
     );
 }


### PR DESCRIPTION
Ankr was removed as a default provider in #305 due its drop in IPv6 connectivity which has since then been resolved. Meanwhile, `Cloudflare` consistently returns an error (`{ "jsonrpc": "2.0", "error": { "code": -32603, "message": "Internal error" }, "id": 1 }`) on any request since several weeks. This PR therefore put `Cloudflare` as last provider (by order of preference , since removing it would be a breaking change) and put back `Ankr` as the third default provider.