### PR TITLE
chore: proposal to upgrade to v2.3.1

### DIFF
--- a/mainnet/proposals/evm_rpc_2025_05_19.md
+++ b/mainnet/proposals/evm_rpc_2025_05_19.md
@@ -1,0 +1,50 @@
+# Proposal to upgrade the EVM RPC canister
+
+Repository: `https://github.com/internet-computer-protocol/evm-rpc-canister.git`
+
+Git hash: `ef17e552b84644ce84ac6a755bc5f9c36beafe02`
+
+New compressed Wasm hash: `c8c423ef81e75c1131e40615d94839d4d976718612a7216ad5b9427f716928aa`
+
+Upgrade args hash: `6005397a2ddf2ee644ceaca123c9afbd2360f0644e7e5e6c4ac320a5f7bd4a82`
+
+Target canister: `7hfb6-caaaa-aaaar-qadga-cai`
+
+Previous EVM RPC proposal: https://dashboard.internetcomputer.org/proposal/135308
+
+---
+
+## Motivation
+
+The Ethereum JSON-RPC provider `Cloudflare` always returns an error (`{ "jsonrpc": "2.0", "error": { "code": -32603, "message": "Internal error" }, "id": 1 }`) for any call,
+while `Ankr` recovered its IPv6 connectivity and seems reliable again.
+The goal of this proposal is to swap the order of those two providers so that the providers for *Ethereum Mainnet* are ordered as follows:
+* `Ankr` becomes the second default JSON-RPC provider.
+* `Cloudflare` is that last one to reduce the likelihood of being selected (removing it completely would be a breaking change from an API standpoint)
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' c3592e02905e68dba671b055468fea97612c0374..ef17e552b84644ce84ac6a755bc5f9c36beafe02 --
+ef17e55 fix: replace Cloudflare with Ankr (#414)
+d04edb8 chore: re-order default Sepolia providers  (#413)
+ ```
+
+## Upgrade args
+
+```
+git fetch
+git checkout ef17e552b84644ce84ac6a755bc5f9c36beafe02
+didc encode -d candid/evm_rpc.did -t '(InstallArgs)' '(record {})' | xxd -r -p | sha256sum
+```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout ef17e552b84644ce84ac6a755bc5f9c36beafe02
+"./scripts/docker-build"
+sha256sum ./evm_rpc.wasm.gz
+```


### PR DESCRIPTION
Proposal to upgrade to [v2.3.1](https://github.com/dfinity/evm-rpc-canister/releases/tag/v2.3.1) to swap Cloudflare with Ankr.