### PR TITLE
fix: missing TraceHttp logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -360,11 +360,12 @@ fn http_request(request: HttpRequest) -> HttpResponse {
                 Some(Ok(priority)) => match priority {
                     Priority::Info => log.push_logs(Priority::Info),
                     Priority::Debug => log.push_logs(Priority::Debug),
-                    Priority::TraceHttp => {}
+                    Priority::TraceHttp => log.push_logs(Priority::TraceHttp),
                 },
                 _ => {
                     log.push_logs(Priority::Info);
                     log.push_logs(Priority::Debug);
+                    log.push_logs(Priority::TraceHttp);
                 }
             }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -880,7 +880,7 @@ fn eth_get_transaction_receipt_should_succeed() {
                 effective_gas_price: 0x2d79883d2000_u64.into(),
                 gas_used: 0x5208_u32.into(),
                 from: "0xa1e4380a3b1f749673e270229993ee55f35663b4".parse().unwrap(),
-                logs: vec! [],
+                logs: vec![],
                 logs_bloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".parse().unwrap(),
                 to: Some("0x5df9b87991262f6ba471f09758cde1c0fc1de734".parse().unwrap()),
                 transaction_index: 0x0_u16.into(),
@@ -899,7 +899,7 @@ fn eth_get_transaction_receipt_should_succeed() {
                 effective_gas_price: 0x17c01a135_u64.into(),
                 gas_used: 0x69892_u32.into(),
                 from: "0xe12e9a6661aeaf57abf95fd060bebb223fbee7dd".parse().unwrap(),
-                logs: vec ![],
+                logs: vec![],
                 logs_bloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".parse().unwrap(),
                 to: None,
                 transaction_index: 0x17_u16.into(),
@@ -2339,6 +2339,46 @@ fn should_fail_when_response_id_inconsistent_with_request_id() {
             .contains("unexpected identifier"),
         "unexpected error: {error}"
     );
+}
+
+#[test]
+fn should_log_request() {
+    let [response_0] = json_rpc_sequential_id(
+        json!({"id":0,"jsonrpc":"2.0","result":{"oldestBlock":"0x11e57f5","baseFeePerGas":["0x9cf6c61b9","0x97d853982","0x9ba55a0b0","0x9543bf98d"],"reward":[["0x0123"]]}}),
+    );
+
+    let setup = EvmRpcSetup::new().mock_api_keys();
+    let response = setup
+        .eth_fee_history(
+            RpcServices::EthMainnet(Some(vec![EthMainnetService::Alchemy])),
+            None,
+            evm_rpc_types::FeeHistoryArgs {
+                block_count: 3_u8.into(),
+                newest_block: evm_rpc_types::BlockTag::Latest,
+                reward_percentiles: None,
+            },
+        )
+        .mock_http_once(MockOutcallBuilder::new(200, response_0))
+        .wait()
+        .expect_consistent()
+        .unwrap();
+    assert_eq!(
+        response,
+        Some(evm_rpc_types::FeeHistory {
+            oldest_block: Nat256::from(0x11e57f5_u64),
+            base_fee_per_gas: vec![0x9cf6c61b9_u64, 0x97d853982, 0x9ba55a0b0, 0x9543bf98d]
+                .into_iter()
+                .map(Nat256::from)
+                .collect(),
+            gas_used_ratio: vec![],
+            reward: vec![vec![Nat256::from(0x0123_u32)]],
+        })
+    );
+
+    let logs = setup.http_get_logs("TRACE_HTTP");
+    assert_eq!(logs.len(), 2, "Unexpected amount of logs {logs:?}");
+    assert!(logs[0].message.contains("JSON-RPC request with id `0` to eth-mainnet.g.alchemy.com: JsonRpcRequest { jsonrpc: V2, method: \"eth_feeHistory\""));
+    assert!(logs[1].message.contains("response for request with id `0`. Response with status 200 OK: JsonRpcResponse { jsonrpc: V2, id: Number(0), result: Ok(FeeHistory"));
 }
 
 pub fn multi_logs_for_single_transaction(num_logs: usize) -> serde_json::Value {


### PR DESCRIPTION
Logs at level `TraceHttp` where not added to the canister response when queried via the HTTP endpoint `/logs`. Similar to dfinity/sol-rpc-canister#129.