### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2025-05-27
+
+### Added
+- Library `canhttp` that contains the handling of HTTPs outcalls ([#364](https://github.com/dfinity/evm-rpc-canister/pull/364), [#370](https://github.com/dfinity/evm-rpc-canister/pull/370), [#374](https://github.com/dfinity/evm-rpc-canister/pull/374), [#375](https://github.com/dfinity/evm-rpc-canister/pull/375), [#378](https://github.com/dfinity/evm-rpc-canister/pull/378) and [#391](https://github.com/dfinity/evm-rpc-canister/pull/391))
+
+### Changed
+
+- Improve validation of JSON-RPC requests and responses to adhere to the JSON-RPC specification ([#386](https://github.com/dfinity/evm-rpc-canister/pull/386) and [#387](https://github.com/dfinity/evm-rpc-canister/pull/387))
+- Re-order default Sepolia providers ([#410](https://github.com/dfinity/evm-rpc-canister/pull/410))
+- Remove `http_types` module and use external `ic-http-types` crate ([#400](https://github.com/dfinity/evm-rpc-canister/pull/400))
+- Update dependencies:
+    - Update Rust and libs ([#418](https://github.com/dfinity/evm-rpc-canister/pull/418))
+    - Bump tokio from 1.44.0 to 1.44.1 ([#389](https://github.com/dfinity/evm-rpc-canister/pull/389))
+    - Bump http from 1.2.0 to 1.3.1 ([#388](https://github.com/dfinity/evm-rpc-canister/pull/388))
+    - Bump ic-stable-structures from 0.6.7 to 0.6.8 ([#390](https://github.com/dfinity/evm-rpc-canister/pull/390))
+    - Bump pocket-ic from 6.0.0 to 7.0.0 ([#376](https://github.com/dfinity/evm-rpc-canister/pull/376))
+    - Bump pin-project from 1.1.9 to 1.1.10 ([#382](https://github.com/dfinity/evm-rpc-canister/pull/382))
+    - Bump thiserror from 2.0.11 to 2.0.12 ([#381](https://github.com/dfinity/evm-rpc-canister/pull/381))
+    - Bump tokio from 1.43.0 to 1.44.0 ([#384](https://github.com/dfinity/evm-rpc-canister/pull/384))
+    - Bump serde_json from 1.0.139 to 1.0.140 ([#385](https://github.com/dfinity/evm-rpc-canister/pull/385))
+    - Bump serde_bytes from 0.11.15 to 0.11.17 ([#380](https://github.com/dfinity/evm-rpc-canister/pull/380))
+    - Bump serde from 1.0.218 to 1.0.219 ([#383](https://github.com/dfinity/evm-rpc-canister/pull/383))
+    - Bump ring from 0.17.8 to 0.17.13 ([#379](https://github.com/dfinity/evm-rpc-canister/pull/379))
+    - Bump serde_json from 1.0.138 to 1.0.139 ([#371](https://github.com/dfinity/evm-rpc-canister/pull/371))
+    - Bump serde from 1.0.217 to 1.0.218 ([#372](https://github.com/dfinity/evm-rpc-canister/pull/372))
+
+### Fixed
+
+- Missing TraceHttp logs ([#421](https://github.com/dfinity/evm-rpc-canister/pull/421))
+- Reject calls to HTTP endpoint in replicated mode ([#373](https://github.com/dfinity/evm-rpc-canister/pull/373))
+- Double `max_response_bytes` when response too big ([#368](https://github.com/dfinity/evm-rpc-canister/pull/368))
+
 ## [2.3.1] - 2025-05-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.4.0] - 2025-06-04
 
 ### Added
+
+- Customize maximum block range for `eth_getLogs` ([#424](https://github.com/dfinity/evm-rpc-canister/pull/424))
 - Library `canhttp` that contains the handling of HTTPs outcalls ([#364](https://github.com/dfinity/evm-rpc-canister/pull/364), [#370](https://github.com/dfinity/evm-rpc-canister/pull/370), [#374](https://github.com/dfinity/evm-rpc-canister/pull/374), [#375](https://github.com/dfinity/evm-rpc-canister/pull/375), [#378](https://github.com/dfinity/evm-rpc-canister/pull/378) and [#391](https://github.com/dfinity/evm-rpc-canister/pull/391))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.4.0] - 2025-05-27
+## [2.4.0] - 2025-06-04
 
 ### Added
 - Library `canhttp` that contains the handling of HTTPs outcalls ([#364](https://github.com/dfinity/evm-rpc-canister/pull/364), [#370](https://github.com/dfinity/evm-rpc-canister/pull/370), [#374](https://github.com/dfinity/evm-rpc-canister/pull/374), [#375](https://github.com/dfinity/evm-rpc-canister/pull/375), [#378](https://github.com/dfinity/evm-rpc-canister/pull/378) and [#391](https://github.com/dfinity/evm-rpc-canister/pull/391))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2025-05-19
+
+### Changed
+
+- Re-order default Sepolia providers ([#413](https://github.com/dfinity/evm-rpc-canister/pull/413))
+
+### Fixed
+
+- Replace Cloudflare with Ankr ([#414](https://github.com/dfinity/evm-rpc-canister/pull/414))
+
 ## [2.3.0] - 2025-02-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "evm_rpc_types"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "candid",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "evm_rpc"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "assert_matches",
  "candid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm_rpc"
-version = "2.3.0"
+version = "2.4.0"
 description = "Interact with EVM blockchains from the Internet Computer."
 authors = ["DFINITY Foundation"]
 readme = "README.md"

--- a/canhttp/CHANGELOG.md
+++ b/canhttp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] - 2025-05-27
 
 ### Added
 

--- a/canhttp/CHANGELOG.md
+++ b/canhttp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2025-05-27
+## [0.1.0] - 2025-06-04
 
 ### Added
 

--- a/canhttp/CHANGELOG.md
+++ b/canhttp/CHANGELOG.md
@@ -6,3 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- JSON-RPC request ID with constant binary size ([#397](https://github.com/dfinity/evm-rpc-canister/pull/397))
+- Use `canhttp` to make parallel calls ([#391](https://github.com/dfinity/evm-rpc-canister/pull/391))
+- Improve validation of JSON-RPC requests and responses to adhere to the JSON-RPC specification ([#386](https://github.com/dfinity/evm-rpc-canister/pull/386) and [#387](https://github.com/dfinity/evm-rpc-canister/pull/387))
+- Retry layer ([#378](https://github.com/dfinity/evm-rpc-canister/pull/378))
+- JSON RPC conversion layer ([#375](https://github.com/dfinity/evm-rpc-canister/pull/375))
+- HTTP conversion layer ([#374](https://github.com/dfinity/evm-rpc-canister/pull/374))
+- Observability layer ([#370](https://github.com/dfinity/evm-rpc-canister/pull/370))
+- Library `canhttp` ([#364](https://github.com/dfinity/evm-rpc-canister/pull/364))

--- a/evm_rpc_types/CHANGELOG.md
+++ b/evm_rpc_types/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2025-06-04
+
+### Added
+
+- Customize maximum block range for `eth_getLogs` ([#424](https://github.com/dfinity/evm-rpc-canister/pull/424))
+
 ## [1.3.0] - 2025-02-11
 
 ### Added

--- a/evm_rpc_types/Cargo.toml
+++ b/evm_rpc_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm_rpc_types"
-version = "1.3.0"
+version = "1.4.0"
 description = "Candid types for interacting with the EVM RPC canister"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Update changelogs and bump version in preparation to the v2.4.0 release.