### PR TITLE
fix: add missing repository in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "canhttp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_matches",
  "candid",

--- a/canhttp/Cargo.toml
+++ b/canhttp/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "canhttp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Rust library to issue HTTPs outcalls from a canister on the Internet Computer"
 license = "Apache-2.0"
 readme = "README.md"
 authors = ["DFINITY Foundation"]
 edition = "2021"
 include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
+repository = "https://github.com/dfinity/evm-rpc-canister"
 documentation = "https://docs.rs/canhttp"
 
 [dependencies]

--- a/canhttp/README.md
+++ b/canhttp/README.md
@@ -4,3 +4,7 @@
 
 
 # canhttp
+
+Library to make [HTTPs outcalls](https://internetcomputer.org/https-outcalls) from a canister on the Internet Computer, leveraging the modularity of the [tower framework](https://rust-lang.guide/guide/learn-async-rust/tower.html).
+
+See the [Rust documentation](https://docs.rs/canhttp) for more details.

--- a/evm_rpc_types/Cargo.toml
+++ b/evm_rpc_types/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 authors = ["DFINITY Foundation"]
 edition = "2021"
 include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
-repository = "https://github.com/internet-computer-protocol/evm-rpc-canister"
+repository = "https://github.com/dfinity/evm-rpc-canister"
 documentation = "https://docs.rs/evm_rpc_types"
 
 


### PR DESCRIPTION
Follow-up on #422 to add missing the `repository` field in `canhttp/Cargo.toml`.