### PR TITLE
chore: proposal to upgrade to v2.4.0

### DIFF
--- a/mainnet/proposals/evm_rpc_20256_06_06.md
+++ b/mainnet/proposals/evm_rpc_20256_06_06.md
@@ -1,0 +1,88 @@
+# Proposal to upgrade the EVM RPC canister
+
+Repository: `https://github.com/internet-computer-protocol/evm-rpc-canister.git`
+
+Git hash: `a56729c2b80d043904c3ba54bd831f5276d358d6`
+
+New compressed Wasm hash: `53ff4625ad3990f22ab8ee1cee85b6ab43cb623e0ca28d3162c41cfac55bd1a6`
+
+Upgrade args hash: `6005397a2ddf2ee644ceaca123c9afbd2360f0644e7e5e6c4ac320a5f7bd4a82`
+
+Target canister: `7hfb6-caaaa-aaaar-qadga-cai`
+
+Previous EVM RPC proposal: https://dashboard.internetcomputer.org/proposal/136701
+
+---
+
+## Motivation
+
+Upgrade the EVM RPC canister to the latest version [v2.4.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/v2.4.0), 
+which includes in particular the following changes:
+* Customize maximum block range for `eth_getLogs`.
+* Extract handling of HTTPs outcalls into a separate library `canhttp`.
+* Improve validation of JSON-RPC requests and responses to adhere to the JSON-RPC specification
+* Re-order default Sepolia providers
+
+See the Gihub release [v2.4.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/v2.4.0) for more details.
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' ef17e552b84644ce84ac6a755bc5f9c36beafe02..a56729c2b80d043904c3ba54bd831f5276d358d6 --
+a56729c chore: release v2.4.0 (#422)
+8b1f5be feat: Customize maximum block range for `eth_getLogs` (#424)
+20d3901 fix: missing TraceHttp logs (#421)
+a7153f5 chore: update Rust and libs (#418)
+8f00015 chore: merge v2.3 (#417)
+c226414 chore: re-order default Sepolia providers (#410)
+1b88d43 refactor(http-types): Remove http_types module and use external ic-http-types crate (#400)
+d5e377b feat(canhttp): JSON-RPC request ID with constant binary size (#397)
+d8d8f22 chore: add NOTICE to Apache license (#398)
+6cade0c feat: make `JsonRpcResponse` map able to return a different type (#395)
+d726102 feat: add map method to `JsonRpcResponse` (#394)
+b976abe refactor: use `canhttp` to make parallel calls (#391)
+5823ac7 build(deps): bump pin-project from 1.1.9 to 1.1.10 (#382)
+1aeeca3 feat: Add a method to retrieve JsonRpcRequest params (#392)
+32afe4b feat: ensure JSON-RPC IDs are consistent (#387)
+c1d9a12 build(deps): bump tokio from 1.44.0 to 1.44.1 (#389)
+7b18fcc build(deps): bump http from 1.2.0 to 1.3.1 (#388)
+57e0e63 build(deps): bump ic-stable-structures from 0.6.7 to 0.6.8 (#390)
+663a692 refactor: adapt JSON RPC request and response types according to the specification (#386)
+ab1c1cd feat: retry layer (#378)
+2369e95 build(deps): bump pocket-ic from 6.0.0 to 7.0.0 (#376)
+69fc1c3 build(deps): bump thiserror from 2.0.11 to 2.0.12 (#381)
+c81ed93 build(deps): bump tokio from 1.43.0 to 1.44.0 (#384)
+5e1ec24 build(deps): bump serde_json from 1.0.139 to 1.0.140 (#385)
+46f0310 build(deps): bump serde_bytes from 0.11.15 to 0.11.17 (#380)
+6eb2eca build(deps): bump serde from 1.0.218 to 1.0.219 (#383)
+84c01ca build(deps): bump ring from 0.17.8 to 0.17.13 (#379)
+4cc3a5a feat: JSON RPC conversion layer (#375)
+9fdcde6 ci: fix reproducible build (#377)
+79f6408 feat: HTTP conversion layer (#374)
+732c179 fix: Reject calls to HTTP endpoint in replicated mode (#373)
+bd02c54 feat: observability layer (#370)
+aff720f build(deps): bump serde_json from 1.0.138 to 1.0.139 (#371)
+1f3c95e build(deps): bump serde from 1.0.217 to 1.0.218 (#372)
+026c729 chore: Proposal to upgrade to v2.3.0 (#369)
+f2b62c4 feat: library `canhttp` (#364)
+890b6b6 test: double `max_response_bytes` when response too big (#368)
+ ```
+
+## Upgrade args
+
+```
+git fetch
+git checkout a56729c2b80d043904c3ba54bd831f5276d358d6
+didc encode -d candid/evm_rpc.did -t '(InstallArgs)' '(record {})' | xxd -r -p | sha256sum
+```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout a56729c2b80d043904c3ba54bd831f5276d358d6
+"./scripts/docker-build"
+sha256sum ./evm_rpc.wasm.gz
+```


### PR DESCRIPTION
Proposal to upgrade the EVM RPC canister [`7hfb6-caaaa-aaaar-qadga-cai`](https://dashboard.internetcomputer.org/canister/7hfb6-caaaa-aaaar-qadga-cai) to [v2.4.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/v2.4.0).