### PR TITLE
fix: `MultiRpcResult::map` for non-injective functions

### DIFF
--- a/evm_rpc_types/src/result/mod.rs
+++ b/evm_rpc_types/src/result/mod.rs
@@ -44,7 +44,7 @@ impl<T: PartialEq> MultiRpcResult<T> {
     /// Collapses an [`Inconsistent`](MultiRpcResult::Inconsistent) into
     /// [`Consistent`](MultiRpcResult::Consistent) if all results match.
     /// Otherwise, returns the value unchanged.
-    pub fn collapse(self) -> MultiRpcResult<T> {
+    fn collapse(self) -> MultiRpcResult<T> {
         match self {
             MultiRpcResult::Consistent(r) => MultiRpcResult::Consistent(r),
             MultiRpcResult::Inconsistent(v) => {

--- a/evm_rpc_types/src/result/tests.rs
+++ b/evm_rpc_types/src/result/tests.rs
@@ -13,15 +13,15 @@ fn test_multi_rpc_result_map() {
         MultiRpcResult::Consistent(Err(err.clone()))
     );
     assert_eq!(
-        MultiRpcResult::Inconsistent(vec![(
-            RpcService::EthMainnet(EthMainnetService::Ankr),
-            Ok(5)
-        )])
+        MultiRpcResult::Inconsistent(vec![
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(5)),
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(6))
+        ])
         .map(|n| n + 1),
-        MultiRpcResult::Inconsistent(vec![(
-            RpcService::EthMainnet(EthMainnetService::Ankr),
-            Ok(6)
-        )])
+        MultiRpcResult::Inconsistent(vec![
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(6)),
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(7))
+        ])
     );
     assert_eq!(
         MultiRpcResult::Inconsistent(vec![
@@ -56,6 +56,14 @@ fn test_multi_rpc_result_map() {
                 Err(err)
             )
         ])
+    );
+    assert_eq!(
+        MultiRpcResult::Inconsistent(vec![(
+            RpcService::EthMainnet(EthMainnetService::Ankr),
+            Ok(2)
+        )])
+        .map(|n| n / 2),
+        MultiRpcResult::Consistent(Ok(1))
     );
     assert_eq!(
         MultiRpcResult::Inconsistent(vec![

--- a/evm_rpc_types/src/result/tests.rs
+++ b/evm_rpc_types/src/result/tests.rs
@@ -57,4 +57,71 @@ fn test_multi_rpc_result_map() {
             )
         ])
     );
+    assert_eq!(
+        MultiRpcResult::Inconsistent(vec![
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(2)),
+            (RpcService::EthMainnet(EthMainnetService::Llama), Ok(3))
+        ])
+        .map(|n| n / 2),
+        MultiRpcResult::Consistent(Ok(1))
+    );
+}
+
+#[test]
+fn test_multi_rpc_result_collapse() {
+    let err = RpcError::ProviderError(ProviderError::ProviderNotFound);
+    assert_eq!(
+        MultiRpcResult::Consistent(Ok(5)).collapse(),
+        MultiRpcResult::Consistent(Ok(5))
+    );
+    assert_eq!(
+        MultiRpcResult::Inconsistent(vec![
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(2)),
+            (RpcService::EthMainnet(EthMainnetService::Llama), Ok(3))
+        ])
+        .collapse(),
+        MultiRpcResult::Inconsistent(vec![
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(2)),
+            (RpcService::EthMainnet(EthMainnetService::Llama), Ok(3))
+        ])
+    );
+    assert_eq!(
+        MultiRpcResult::Inconsistent(vec![
+            (
+                RpcService::EthMainnet(EthMainnetService::Ankr),
+                Err(err.clone())
+            ),
+            (RpcService::EthMainnet(EthMainnetService::Llama), Ok(2))
+        ])
+        .collapse(),
+        MultiRpcResult::Inconsistent(vec![
+            (
+                RpcService::EthMainnet(EthMainnetService::Ankr),
+                Err(err.clone())
+            ),
+            (RpcService::EthMainnet(EthMainnetService::Llama), Ok(2))
+        ])
+    );
+    assert_eq!(
+        MultiRpcResult::Inconsistent(vec![
+            (RpcService::EthMainnet(EthMainnetService::Ankr), Ok(2)),
+            (RpcService::EthMainnet(EthMainnetService::Llama), Ok(2))
+        ])
+        .collapse(),
+        MultiRpcResult::Consistent(Ok(2))
+    );
+    assert_eq!(
+        MultiRpcResult::Inconsistent::<()>(vec![
+            (
+                RpcService::EthMainnet(EthMainnetService::Ankr),
+                Err(err.clone())
+            ),
+            (
+                RpcService::EthMainnet(EthMainnetService::Llama),
+                Err(err.clone())
+            )
+        ])
+        .collapse(),
+        MultiRpcResult::Consistent::<()>(Err(err.clone()))
+    );
 }


### PR DESCRIPTION
Previously, `MultiRpcResult::map` always returned `Consistent` → `Consistent` and `Inconsistent` → `Inconsistent`. With non-injective functions, this could produce an `Inconsistent` variant whose results were all equal.

This change updates `map` so that after applying the function, any `Inconsistent` results that are all equal are collapsed into a single `Consistent` result. 

A new `collapse` performing this operation is also added to `MultiRpcResult`.