### PR TITLE
chore: handle `max_response_bytes` is exceeded error in metrics

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -144,6 +144,7 @@ type Metrics = record {
   inconsistentResponses : vec record { record { text; text }; nat64 };
   cyclesCharged : vec record { record { text; text }; nat };
   errHttpOutcall : vec record { record { text; text; RejectionCode }; nat64 };
+  errMaxResponseSizeExceeded : vec record { record { text; text }; nat64 };
 };
 type MultiFeeHistoryResult = variant {
   Consistent : FeeHistoryResult;

--- a/src/http.rs
+++ b/src/http.rs
@@ -134,75 +134,74 @@ where
                     );
                 })
                 .on_error(
-                    |req_data: MetricData, error: &HttpClientError|
-                        match error {
-                            HttpClientError::IcError(IcError { code, message }) => {
-                                if error.is_response_too_large() {
-                                    add_metric_entry!(
-                                        err_max_response_size_exceeded,
-                                        (req_data.method, req_data.host),
-                                        1
-                                    );
-                                } else {
-                                    add_metric_entry!(
-                                        err_http_outcall,
-                                        (req_data.method, req_data.host, LegacyRejectionCode::from(*code)),
-                                        1
-                                    );
-                                    log!(
-                                        Priority::TraceHttp,
-                                        "IC Error for request with id `{}` with code `{}` and message `{}`",
-                                        req_data.request_id,
-                                        code,
-                                        message,
-                                    );
-                                }
-                            }
-                            HttpClientError::UnsuccessfulHttpResponse(
-                                FilterNonSuccessfulHttpResponseError::UnsuccessfulResponse(response),
-                            ) => {
-                                observe_response(
-                                    req_data.method,
-                                    req_data.host,
-                                    response.status().as_u16(),
+                    |req_data: MetricData, error: &HttpClientError| match error {
+                        HttpClientError::IcError(IcError { code, message }) => {
+                            if error.is_response_too_large() {
+                                add_metric_entry!(
+                                    err_max_response_size_exceeded,
+                                    (req_data.method, req_data.host),
+                                    1
+                                );
+                            } else {
+                                add_metric_entry!(
+                                    err_http_outcall,
+                                    (req_data.method, req_data.host, LegacyRejectionCode::from(*code)),
+                                    1
                                 );
                                 log!(
                                     Priority::TraceHttp,
-                                    "Unsuccessful HTTP response for request with id `{}`. Response with status {}: {}",
+                                    "IC Error for request with id `{}` with code `{}` and message `{}`",
                                     req_data.request_id,
-                                    response.status(),
-                                    String::from_utf8_lossy(response.body())
+                                    code,
+                                    message,
                                 );
                             }
-                            HttpClientError::InvalidJsonResponse(
-                                JsonResponseConversionError::InvalidJsonResponse {
-                                    status,
-                                    body: _,
-                                    parsing_error: _,
-                                },
-                            ) => {
-                                observe_response(req_data.method, req_data.host, *status);
-                                log!(
-                                    Priority::TraceHttp,
-                                    "Invalid JSON RPC response for request with id `{}`: {}",
-                                    req_data.request_id,
-                                    error
-                                );
-                            }
-                            HttpClientError::InvalidJsonResponseId(ConsistentResponseIdFilterError::InconsistentId { status, request_id: _, response_id: _ }) => {
-                                observe_response(req_data.method, req_data.host, *status);
-                                log!(
-                                    Priority::TraceHttp,
-                                    "Invalid JSON RPC response for request with id `{}`: {}",
-                                    req_data.request_id,
-                                    error
-                                );
-                            }
-                            HttpClientError::NotHandledError(e) => {
-                                log!(Priority::Info, "BUG: Unexpected error: {}", e);
-                            }
-                            HttpClientError::CyclesAccountingError(_) => {}
-                        }),
+                        }
+                        HttpClientError::UnsuccessfulHttpResponse(
+                            FilterNonSuccessfulHttpResponseError::UnsuccessfulResponse(response),
+                        ) => {
+                            observe_response(
+                                req_data.method,
+                                req_data.host,
+                                response.status().as_u16(),
+                            );
+                            log!(
+                                Priority::TraceHttp,
+                                "Unsuccessful HTTP response for request with id `{}`. Response with status {}: {}",
+                                req_data.request_id,
+                                response.status(),
+                                String::from_utf8_lossy(response.body())
+                            );
+                        }
+                        HttpClientError::InvalidJsonResponse(
+                            JsonResponseConversionError::InvalidJsonResponse {
+                                status,
+                                body: _,
+                                parsing_error: _,
+                            },
+                        ) => {
+                            observe_response(req_data.method, req_data.host, *status);
+                            log!(
+                                Priority::TraceHttp,
+                                "Invalid JSON RPC response for request with id `{}`: {}",
+                                req_data.request_id,
+                                error
+                            );
+                        }
+                        HttpClientError::InvalidJsonResponseId(ConsistentResponseIdFilterError::InconsistentId { status, request_id: _, response_id: _ }) => {
+                            observe_response(req_data.method, req_data.host, *status);
+                            log!(
+                                Priority::TraceHttp,
+                                "Invalid JSON RPC response for request with id `{}`: {}",
+                                req_data.request_id,
+                                error
+                            );
+                        }
+                        HttpClientError::NotHandledError(e) => {
+                            log!(Priority::Info, "BUG: Unexpected error: {}", e);
+                        }
+                        HttpClientError::CyclesAccountingError(_) => {}
+                    }),
         )
         .filter_response(CreateJsonRpcIdFilter::new())
         .layer(service_request_builder())

--- a/src/http.rs
+++ b/src/http.rs
@@ -84,7 +84,7 @@ pub async fn json_rpc_request(
 pub fn http_client<I, O>(
     rpc_method: MetricRpcMethod,
     retry: bool,
-) -> impl Service<HttpJsonRpcRequest<I>, Response=HttpJsonRpcResponse<O>, Error=RpcError>
+) -> impl Service<HttpJsonRpcRequest<I>, Response = HttpJsonRpcResponse<O>, Error = RpcError>
 where
     I: Serialize + Clone + Debug,
     O: DeserializeOwned + Debug,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -164,7 +164,7 @@ pub struct Metrics {
     pub cycles_charged: HashMap<(MetricRpcMethod, MetricRpcHost), u128>,
     #[serde(rename = "errHttpOutcall")]
     pub err_http_outcall: HashMap<(MetricRpcMethod, MetricRpcHost, LegacyRejectionCode), u64>,
-    #[serde(rename = "maxResponseSizeExceeded")]
+    #[serde(rename = "errMaxResponseSizeExceeded")]
     pub err_max_response_size_exceeded: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -164,6 +164,8 @@ pub struct Metrics {
     pub cycles_charged: HashMap<(MetricRpcMethod, MetricRpcHost), u128>,
     #[serde(rename = "errHttpOutcall")]
     pub err_http_outcall: HashMap<(MetricRpcMethod, MetricRpcHost, LegacyRejectionCode), u64>,
+    #[serde(rename = "maxResponseSizeExceeded")]
+    pub err_max_response_size_exceeded: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2392,8 +2392,8 @@ fn should_have_different_request_ids_when_retrying_because_response_too_big() {
             responses: hashmap! {
                 (rpc_method(), CLOUDFLARE_HOSTNAME.into(), 200.into()) => 1,
             },
-            err_http_outcall: hashmap! {
-                (rpc_method(), CLOUDFLARE_HOSTNAME.into(), LegacyRejectionCode::SysFatal) => 1,
+            err_max_response_size_exceeded: hashmap! {
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into()) => 1,
             },
             ..Default::default()
         }


### PR DESCRIPTION
([XC-482](https://dfinity.atlassian.net/browse/XC-482)) Currently, the error metrics are incremented on all `SYS_FATAL` error responses. However, this error also occurs when the response size exceeds `max_response_bytes`, which is a client error. As such, a new dedicated metric for `max_response_bytes` exceeded is added, and separated from other IC error metrics.

[XC-482]: https://dfinity.atlassian.net/browse/XC-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ