### PR TITLE
feat: add `eth_sendRawTransaction` client support

### DIFF
--- a/evm_rpc_client/src/lib.rs
+++ b/evm_rpc_client/src/lib.rs
@@ -577,7 +577,7 @@ impl<R> EvmRpcClient<R> {
     ///     .await
     ///     .expect_consistent();
     ///
-    /// assert_eq!(result, Ok(Some(b256!("0x33469b22e9f636356c4160a87eb19df52b7412e8eac32a4a55ffe88ea8350788"))));
+    /// assert_eq!(result, Ok(b256!("0x33469b22e9f636356c4160a87eb19df52b7412e8eac32a4a55ffe88ea8350788")));
     /// # Ok(())
     /// # }
     /// ```

--- a/evm_rpc_client/src/request/mod.rs
+++ b/evm_rpc_client/src/request/mod.rs
@@ -255,7 +255,7 @@ impl EvmRpcRequest for SendRawTransactionRequest {
     type Config = RpcConfig;
     type Params = Hex;
     type CandidOutput = MultiRpcResult<evm_rpc_types::SendRawTransactionStatus>;
-    type Output = MultiRpcResult<Option<alloy_primitives::B256>>;
+    type Output = MultiRpcResult<alloy_primitives::B256>;
 
     fn endpoint(&self) -> EvmRpcEndpoint {
         EvmRpcEndpoint::SendRawTransaction
@@ -271,7 +271,7 @@ pub type SendRawTransactionRequestBuilder<R> = RequestBuilder<
     RpcConfig,
     Hex,
     MultiRpcResult<evm_rpc_types::SendRawTransactionStatus>,
-    MultiRpcResult<Option<alloy_primitives::B256>>,
+    MultiRpcResult<alloy_primitives::B256>,
 >;
 
 /// Ethereum RPC endpoint supported by the EVM RPC canister.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1197,7 +1197,7 @@ async fn eth_send_raw_transaction_should_succeed() {
             .expect_consistent()
             .unwrap();
 
-        assert_eq!(response, Some(MOCK_TRANSACTION_HASH));
+        assert_eq!(response, MOCK_TRANSACTION_HASH);
     }
 }
 
@@ -1505,7 +1505,7 @@ async fn candid_rpc_should_return_inconsistent_results() {
         vec![
             (
                 RpcService::EthMainnet(EthMainnetService::Ankr),
-                Ok(Some(MOCK_TRANSACTION_HASH))
+                Ok(MOCK_TRANSACTION_HASH)
             ),
             (
                 RpcService::EthMainnet(EthMainnetService::Cloudflare),
@@ -1905,7 +1905,7 @@ async fn candid_rpc_should_handle_already_known() {
         .send()
         .await
         .expect_consistent();
-    assert_eq!(result, Ok(Some(MOCK_TRANSACTION_HASH)));
+    assert_eq!(result, Ok(MOCK_TRANSACTION_HASH));
     let rpc_method = || RpcMethod::EthSendRawTransaction.into();
     assert_eq!(
         setup.get_metrics().await,


### PR DESCRIPTION
(XC-412) Add support to the EVM RPC client for the `eth_sendRawTransaction` endpoint.