### PR TITLE
chore: proposal to upgrade to v2.5.0

### DIFF
--- a/mainnet/proposals/evm_rpc_20256_09_12.md
+++ b/mainnet/proposals/evm_rpc_20256_09_12.md
@@ -1,0 +1,71 @@
+# Proposal to upgrade the EVM RPC canister
+
+Repository: `https://github.com/dfinity/evm-rpc-canister.git`
+
+Git hash: `864f38c9fd4be34387332fbb992368c343cabacc`
+
+New compressed Wasm hash: `0d99ec53d3efed4bb8171294c0d184033d7a008afc76b63e49f693d86a84add3`
+
+Upgrade args hash: `6005397a2ddf2ee644ceaca123c9afbd2360f0644e7e5e6c4ac320a5f7bd4a82`
+
+Target canister: `7hfb6-caaaa-aaaar-qadga-cai`
+
+Previous EVM RPC proposal: https://dashboard.internetcomputer.org/proposal/136897
+
+---
+
+## Motivation
+Upgrade the EVM RPC canister to the latest version [v2.5.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/v2.5.0),
+which includes in particular the following changes:
+* Dynamically select supported providers based on the successful responses rate in the last 20min.
+* Update the URLs of the BlockPi public endpoints.
+
+See the Gihub release [v2.5.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/v2.5.0) for more details.
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' a56729c2b80d043904c3ba54bd831f5276d358d6..864f38c9fd4be34387332fbb992368c343cabacc --
+864f38c chore: release v2.5.0 (#468)
+1628521 chore: release `evm_rpc_types` v2.1.0 (#469)
+7747440 feat: add support for `eth_feeHistory` to client (#460)
+6bd564b feat: add support for `eth_getBlockByNumber` to client (#459)
+df5922c chore: handle `max_response_bytes` is exceeded error in metrics (#463)
+d41b123 test: client integration test infrastructure (#448)
+63adada feat: add EVM RPC canister client (#447)
+aa4b14a fix: `MultiRpcResult::map` for non-injective functions (#456)
+f05eefa chore: release `evm_rpc_types` v2.0.0 (#451)
+65c667d build: ensure that `evm_rpc_types` does not depend on `ic-cdk` (#450)
+65e4d24 build: update dependencies (#449)
+024fbe3 chore: remove canhttp (#443)
+3995dbd chore: release canhttp v0.2.0 (#442)
+21be03b feat: Select supported providers based on successful responses (#435)
+9fafbb5 feat: Store limited number of expiring elements (#434)
+8c4ef03 fix: Update URLs of BlockPi public endpoints (#440)
+1d238ff refactor!: use `canlog` crate (#437)
+db898e4 fix: metric name for `eth_call`  (#439)
+e92b0cb refactor: remove default/non-default providers (#436)
+8ce6e35 feat: add `as_array` methods to `Hex` types in `evm_rpc_types` (#432)
+178bd93 chore: proposal to upgrade to v2.4.0 (#427)
+9438916 build!: remove `ic_cdk` from `evm_rpc_types` dependencies (#428)
+77b2398 fix: add missing repository in Cargo.toml (#425)
+ ```
+
+## Upgrade args
+
+```
+git fetch
+git checkout 864f38c9fd4be34387332fbb992368c343cabacc
+didc encode -d candid/evm_rpc.did -t '(InstallArgs)' '(record {})' | xxd -r -p | sha256sum
+```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout 864f38c9fd4be34387332fbb992368c343cabacc
+"./scripts/docker-build"
+sha256sum ./evm_rpc.wasm.gz
+```


### PR DESCRIPTION
Proposal to upgrade the EVM RPC canister [7hfb6-caaaa-aaaar-qadga-cai](https://dashboard.internetcomputer.org/canister/7hfb6-caaaa-aaaar-qadga-cai) to [v2.5.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/v2.5.0).