### PR TITLE
feat!: add support for `eth_getTransactionReceipt` response fields

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -284,6 +284,7 @@ type Topic = vec text;
 type TransactionReceipt = record {
   to : opt text;
   status : opt nat;
+  root : opt text;
   transactionHash : text;
   blockNumber : nat;
   from : text;
@@ -295,6 +296,7 @@ type TransactionReceipt = record {
   logsBloom : text;
   contractAddress : opt text;
   gasUsed : nat;
+  cumulativeGasUsed : nat;
 };
 type ValidationError = variant {
   Custom : text;

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -94,7 +94,7 @@ pub struct TransactionReceipt {
     #[serde(rename = "gasUsed")]
     pub gas_used: Nat256,
 
-    /// The amount of gas used by this specific transaction alone
+    /// The sum of gas used by this transaction and all preceding transactions in the same block.
     #[serde(rename = "cumulativeGasUsed")]
     pub cumulative_gas_used: Nat256,
 

--- a/evm_rpc_types/src/response/mod.rs
+++ b/evm_rpc_types/src/response/mod.rs
@@ -94,9 +94,17 @@ pub struct TransactionReceipt {
     #[serde(rename = "gasUsed")]
     pub gas_used: Nat256,
 
+    /// The amount of gas used by this specific transaction alone
+    #[serde(rename = "cumulativeGasUsed")]
+    pub cumulative_gas_used: Nat256,
+
     /// Either 1 (success) or 0 (failure).
     /// Only specified for transactions included after the Byzantium upgrade.
     pub status: Option<Nat256>,
+
+    /// The post-transaction state root.
+    /// Only specified for transactions included before the Byzantium upgrade.
+    pub root: Option<Hex32>,
 
     /// The hash of the transaction
     #[serde(rename = "transactionHash")]

--- a/src/candid_rpc/cketh_conversion.rs
+++ b/src/candid_rpc/cketh_conversion.rs
@@ -120,10 +120,12 @@ pub(super) fn from_transaction_receipt(
         block_number: value.block_number.into(),
         effective_gas_price: value.effective_gas_price.into(),
         gas_used: value.gas_used.into(),
+        cumulative_gas_used: value.cumulative_gas_used.into(),
         status: value.status.map(|v| match v {
             crate::rpc_client::json::responses::TransactionStatus::Success => Nat256::from(1_u8),
             crate::rpc_client::json::responses::TransactionStatus::Failure => Nat256::from(0_u8),
         }),
+        root: value.root.map(Hash::into_bytes).map(Hex32::from),
         transaction_hash: Hex32::from(value.transaction_hash.into_bytes()),
         contract_address: value
             .contract_address

--- a/src/rpc_client/json/responses.rs
+++ b/src/rpc_client/json/responses.rs
@@ -19,15 +19,15 @@ pub struct TransactionReceipt {
     #[serde(rename = "blockNumber")]
     pub block_number: BlockNumber,
 
-    /// The total base charge plus tip paid for each unit of gas
+    /// The total base charge plus tip paid for each unit of gas.
     #[serde(rename = "effectiveGasPrice")]
     pub effective_gas_price: WeiPerGas,
 
-    /// The amount of gas used by this specific transaction alone
+    /// The sum of gas used by this transaction and all preceding transactions in the same block.
     #[serde(rename = "cumulativeGasUsed")]
     pub cumulative_gas_used: GasAmount,
 
-    /// The sum of gas used by this transaction and all preceding transactions in the same block.
+    /// The amount of gas used for this specific transaction alone.
     #[serde(rename = "gasUsed")]
     pub gas_used: GasAmount,
 

--- a/src/rpc_client/json/responses.rs
+++ b/src/rpc_client/json/responses.rs
@@ -24,11 +24,20 @@ pub struct TransactionReceipt {
     pub effective_gas_price: WeiPerGas,
 
     /// The amount of gas used by this specific transaction alone
+    #[serde(rename = "cumulativeGasUsed")]
+    pub cumulative_gas_used: GasAmount,
+
+    /// The sum of gas used by this transaction and all preceding transactions in the same block.
     #[serde(rename = "gasUsed")]
     pub gas_used: GasAmount,
 
     /// Status of the transaction.
+    /// Only specified for transactions included after the Byzantium upgrade.
     pub status: Option<TransactionStatus>,
+
+    /// The post-transaction state root.
+    /// Only specified for transactions included before the Byzantium upgrade.
+    pub root: Option<Hash>,
 
     /// The hash of the transaction
     #[serde(rename = "transactionHash")]

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -117,8 +117,6 @@ mod eth_get_transaction_receipt {
         )
     }
 
-
-
     #[test]
     fn should_deserialize_post_byzantium_transaction_receipt() {
         const RECEIPT: &str = r#"{

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -69,7 +69,58 @@ mod eth_get_transaction_receipt {
     use std::str::FromStr;
 
     #[test]
-    fn should_deserialize_transaction_receipt() {
+    fn should_deserialize_pre_byzantium_transaction_receipt() {
+        const RECEIPT: &str = r#"{
+        "blockHash": "0x9b3c1d182975fdaa5797879cbc45d6b00a84fb3b13980a107645b2491bcca899",
+        "blockNumber": "0x3d08ff",
+        "contractAddress": null,
+        "cumulativeGasUsed": "0x3a827d",
+        "effectiveGasPrice": "0x4e3b29200",
+        "from": "0xcaf8925d8e825ebe0cb3fc34a2be2c8c737c1ecc",
+        "gasUsed": "0x5208",
+        "logs": [],
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "root": "0xc13704a89e282b166ecf5ac93f7f7c1be7141572c1ce4cc8aae28d526d535b4d",
+        "to": "0x0f1f8a981160a93da959484216b0b8db0ce2cd8e",
+        "transactionHash": "0x48614dab7303dda8ecfa52c6f583a3e09b3bc1724fb5a1512c361f2b36ed242d",
+        "transactionIndex": "0x14",
+        "type": "0x0"
+    }"#;
+
+        let receipt: TransactionReceipt = serde_json::from_str(RECEIPT).unwrap();
+
+        assert_eq!(
+            receipt,
+            TransactionReceipt {
+                block_hash: Hash::from_str(
+                    "0x9b3c1d182975fdaa5797879cbc45d6b00a84fb3b13980a107645b2491bcca899"
+                )
+                    .unwrap(),
+                block_number: BlockNumber::new(0x3d08ff),
+                effective_gas_price: WeiPerGas::new(0x4e3b29200),
+                cumulative_gas_used: GasAmount::new(0x3a827d),
+                gas_used: GasAmount::new(0x5208),
+                status: None,
+                root: Some(Hash::from_str("0xc13704a89e282b166ecf5ac93f7f7c1be7141572c1ce4cc8aae28d526d535b4d").unwrap()),
+                transaction_hash: Hash::from_str(
+                    "0x48614dab7303dda8ecfa52c6f583a3e09b3bc1724fb5a1512c361f2b36ed242d"
+                )
+                    .unwrap(),
+                contract_address: None,
+                from: "0xcaf8925d8e825ebe0cb3fc34a2be2c8c737c1ecc".parse().unwrap(),
+                logs: vec![],
+                logs_bloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".parse().unwrap(),
+                to: Some("0x0f1f8a981160a93da959484216b0b8db0ce2cd8e".parse().unwrap()),
+                transaction_index: 0x14_u32.into(),
+                tx_type: JsonByte::new(0),
+            }
+        )
+    }
+
+
+
+    #[test]
+    fn should_deserialize_post_byzantium_transaction_receipt() {
         const RECEIPT: &str = r#"{
         "transactionHash": "0x0e59bd032b9b22aca5e2784e4cf114783512db00988c716cf17a1cc755a0a93d",
         "blockHash": "0x82005d2f17b251900968f01b0ed482cb49b7e1d797342bc504904d442b64dbe4",
@@ -98,8 +149,10 @@ mod eth_get_transaction_receipt {
                     .unwrap(),
                 block_number: BlockNumber::new(0x4132ec),
                 effective_gas_price: WeiPerGas::new(0xfefbee3e),
+                cumulative_gas_used: GasAmount::new(0x8b2e10),
                 gas_used: GasAmount::new(0x5208),
                 status: Some(TransactionStatus::Success),
+                root: None,
                 transaction_hash: Hash::from_str(
                     "0x0e59bd032b9b22aca5e2784e4cf114783512db00988c716cf17a1cc755a0a93d"
                 )

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -607,6 +607,7 @@ fn should_decode_address() {
 fn should_decode_transaction_receipt() {
     let value = evm_rpc_types::TransactionReceipt {
         status: Some(0x1_u8.into()),
+        root: None,
         transaction_hash: "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f"
             .parse()
             .unwrap(),
@@ -627,6 +628,7 @@ fn should_decode_transaction_receipt() {
             .unwrap()),
         transaction_index: 0xd9_u16.into(),
         tx_type: "0x2".parse().unwrap(),
+        cumulative_gas_used: 0xf02aed_u64.into(),
     };
     assert_eq!(
         Decode!(&Encode!(&value).unwrap(), evm_rpc_types::TransactionReceipt).unwrap(),
@@ -1048,6 +1050,7 @@ fn eth_get_transaction_receipt_should_succeed() {
             raw_body: json!({"jsonrpc":"2.0","id":0,"result":{"blockHash":"0x5115c07eb1f20a9d6410db0916ed3df626cfdab161d3904f45c8c8b65c90d0be","blockNumber":"0x11a85ab","contractAddress":null,"cumulativeGasUsed":"0xf02aed","effectiveGasPrice":"0x63c00ee76","from":"0x0aa8ebb6ad5a8e499e550ae2c461197624c6e667","gasUsed":"0x7d89","logs":[],"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","status":"0x1","to":"0x356cfd6e6d0000400000003900b415f80669009e","transactionHash":"0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f","transactionIndex":"0xd9","type":"0x2"}}),
             expected: evm_rpc_types::TransactionReceipt {
                 status: Some(0x1_u8.into()),
+                root: None,
                 transaction_hash: "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f".parse().unwrap(),
                 contract_address: None,
                 block_number: 0x11a85ab_u64.into(),
@@ -1060,13 +1063,15 @@ fn eth_get_transaction_receipt_should_succeed() {
                 to: Some("0x356cfd6e6d0000400000003900b415f80669009e".parse().unwrap()),
                 transaction_index: 0xd9_u16.into(),
                 tx_type: "0x2".parse().unwrap(),
+                cumulative_gas_used: 0xf02aed_u64.into(),
             },
         },
         TestCase { //first transaction after genesis
             request: "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060",
-            raw_body: json!({"jsonrpc":"2.0","id":0,"result":{"transactionHash":"0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060","blockHash":"0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd","blockNumber":"0xb443","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","gasUsed":"0x5208","root":"0x96a8e009d2b88b1483e6941e6812e32263b05683fac202abc622a3e31aed1957","contractAddress":null,"cumulativeGasUsed":"0x5208","transactionIndex":"0x0","from":"0xa1e4380a3b1f749673e270229993ee55f35663b4","to":"0x5df9b87991262f6ba471f09758cde1c0fc1de734","type":"0x0","effectiveGasPrice":"0x2d79883d2000","logs":[]}}),
+            raw_body: json!({"jsonrpc":"2.0","id":0,"result":{"transactionHash":"0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060","blockHash":"0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd","blockNumber":"0xb443","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","gasUsed":"0x5208","root":"0x96a8e009d2b88b1483e6941e6812e32263b05683fac202abc622a3e31aed1957","contractAddress":null,"cumulativeGasUsed":"0x5208","transactionIndex":"0x0","from":"0xa1e4380a3b1f749673e270229993ee55f35663b4","to":"0x5df9b87991262f6ba471f09758cde1c0fc1de734","type":"0x0","effectiveGasPrice":"0x2d79883d2000","logs":[],"root":"0x96a8e009d2b88b1483e6941e6812e32263b05683fac202abc622a3e31aed1957"}}),
             expected: evm_rpc_types::TransactionReceipt {
                 status: None,
+                root: Some("0x96a8e009d2b88b1483e6941e6812e32263b05683fac202abc622a3e31aed1957".parse().unwrap()),
                 transaction_hash: "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060".parse().unwrap(),
                 contract_address: None,
                 block_number: 0xb443_u64.into(),
@@ -1079,6 +1084,7 @@ fn eth_get_transaction_receipt_should_succeed() {
                 to: Some("0x5df9b87991262f6ba471f09758cde1c0fc1de734".parse().unwrap()),
                 transaction_index: 0x0_u16.into(),
                 tx_type: "0x0".parse().unwrap(),
+                cumulative_gas_used: 0x5208_u64.into(),
             },
         },
         TestCase { //contract creation
@@ -1086,6 +1092,7 @@ fn eth_get_transaction_receipt_should_succeed() {
             raw_body: json!({"jsonrpc":"2.0","id":0,"result":{"transactionHash":"0x2b8e12d42a187ace19c64b47fae0955def8859bf966c345102c6d3a52f28308b","blockHash":"0xd050426a753a7cc4833ba15a5dfcef761fd983f5277230ea8dc700eadd307363","blockNumber":"0x12e64fd","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","gasUsed":"0x69892","contractAddress":"0x6abda0438307733fc299e9c229fd3cc074bd8cc0","cumulativeGasUsed":"0x3009d2","transactionIndex":"0x17","from":"0xe12e9a6661aeaf57abf95fd060bebb223fbee7dd","to":null,"type":"0x2","effectiveGasPrice":"0x17c01a135","logs":[],"status":"0x1"}}),
             expected: evm_rpc_types::TransactionReceipt {
                 status: Some(0x1_u8.into()),
+                root: None,
                 transaction_hash: "0x2b8e12d42a187ace19c64b47fae0955def8859bf966c345102c6d3a52f28308b".parse().unwrap(),
                 contract_address: Some("0x6abda0438307733fc299e9c229fd3cc074bd8cc0".parse().unwrap()),
                 block_number: 0x12e64fd_u64.into(),
@@ -1098,6 +1105,7 @@ fn eth_get_transaction_receipt_should_succeed() {
                 to: None,
                 transaction_index: 0x17_u16.into(),
                 tx_type: "0x2".parse().unwrap(),
+                cumulative_gas_used: 0x3009d2_u64.into(),
             },
         }
     ];


### PR DESCRIPTION
(XC-412) Add support for the `root` and `cumulativeGasUsed` fields in the response to `eth_getTransactionReceipt`: 
* The `root` field is mandatory for transactions included pre-Byzantium and represents the post-transaction state root.
* The `cumulativeGasUsed` is mandatory for all transactions and represents the sum of gas used by this transaction and all preceding transactions in the same block.

This is **not** breaking for the canister Candid API since adding a new field to a returned type is not breaking. 

BREAKING: This is only breaking for the `evm_rpc_types` crate since it adds new fields to the public `evm_rpc_types::TransactionsReceipt` type. 