### PR TITLE
ci: add release and publish pipelines

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,109 @@
+name: Publish
+
+on:
+  workflow_dispatch
+
+jobs:
+  # Release unpublished packages.
+  release-plz-release:
+    name: Publish artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    concurrency:
+      group: publish
+      cancel-in-progress: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Download build for Release Candidate"
+        #     Adapted from [Internet Identity](https://github.com/dfinity/internet-identity/blob/c33e9f65a8045cbedde6f96cfb7f7cb677694fc9/.github/workflows/deploy-rc.yml#L22)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Find all artifacts for the production build, and filter for non-expired main artifacts
+            const allArtifacts = await github.paginate(github.rest.actions.listArtifactsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "evm_rpc_canister.wasm.gz",
+            });
+            const artifactsByBranch = {};
+            const mainArtifacts = allArtifacts
+              .filter(artifact => !artifact.expired)
+              .filter(artifact => artifact.workflow_run.head_branch === "main");
+
+            // Grab the latest artifact
+            mainArtifacts.sort((a,b) => new Date(b.updated_at) - new Date(a.updated_at));
+            const latestMainArtifact = mainArtifacts[0];
+            if(!latestMainArtifact) {
+              const message = "Could not find an artifact to deploy from branch main, are artifacts expired?";
+              console.error(message);
+              throw new Error(message);
+            }
+            console.log("found artifact for commit", latestMainArtifact.workflow_run.head_sha);
+
+            // Download and unzip artifact
+            const { url } = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: latestMainArtifact.id,
+              archive_format: "zip",
+            });
+            await exec.exec('curl', ['-sSL', url, '-o', "artifact.zip"]);
+            await exec.exec('unzip', ["artifact.zip" ]);
+            await exec.exec('rm', ["artifact.zip" ]);
+
+      - name: "SHA256 of release asset"
+        run: |
+          set -e
+          SHA256=$(shasum -a 256 ./evm_rpc_canister.wasm.gz | cut -d ' ' -f1)
+          echo "SHA256 of evm_rpc_canister.wasm.gz: $SHA256"
+          echo "EVM_RPC_CANISTER_WASM_GZ_SHA256=$SHA256" >> "$GITHUB_ENV"
+
+      - name: "Install parse-changelog"
+        uses: taiki-e/install-action@parse-changelog
+
+      - name: "Run release-plz"
+        id: release-plz
+        uses: release-plz/action@bbd1afc9813d25602e002b29e96e0aacebab1160 # v0.5.105
+        with:
+          command: release
+          version: 0.3.142
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: "Generate Github release body"
+        env:
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
+          RELEASES_CREATED: ${{ steps.release-plz.outputs.releases_created }}
+        run: |
+          set -e
+          echo "releases: $RELEASES" # example: [{"package_name":"my-package","prs":[{"html_url":"https://github.com/user/proj/pull/1439","number":1439}],"tag":"v0.1.0","version":"0.1.0"}]
+          echo "releases_created: $RELEASES_CREATED" # example: true
+
+          release_tag=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "evm_rpc_canister") | .tag')
+          echo "release_tag: $release_tag"
+          echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
+          
+          release_version=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "evm_rpc_canister") | .version')
+          echo "release_version: $release_version"
+          echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+          
+          notes=$(parse-changelog canister/CHANGELOG.md "$release_version")
+          
+          CHANGELOG="$notes" envsubst < release_notes.md >> ${{ github.workspace }}-RELEASE.txt
+
+      - name: "Create Github release"
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          tag_name: ${{ env.RELEASE_TAG}}
+          body_path: ${{ github.workspace }}-RELEASE.txt
+          files: |
+            evm_rpc_canister.wasm.gz
+            canister/evm_rpc_canister.did

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,7 @@
 name: Release
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - edited
-      - synchronize
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   # Create a PR with the new versions and changelog, preparing the next release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  workflow_dispatch
+
+jobs:
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run release-plz
+        uses: release-plz/action@bbd1afc9813d25602e002b29e96e0aacebab1160 # v0.5.105
+        with:
+          command: release-pr
+          version: 0.3.142
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,13 @@
 name: Release
 
 on:
-  workflow_dispatch
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+  workflow_dispatch:
 
 jobs:
   # Create a PR with the new versions and changelog, preparing the next release.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,70 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+# template for the changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+# template for the changelog footer
+footer = """
+{% for release in releases -%}
+    {% if release.version -%}
+        {% if release.previous.version -%}
+            [{{ release.version | trim_start_matches(pat="v") }}]: \
+                https://github.com/dfinity/sol-rpc-canister\
+                    /compare/{{ release.previous.version }}..{{ release.version }}
+        {% endif -%}
+    {% else -%}
+        [unreleased]: https://github.com/dfinity/sol-rpc-canister\
+            /compare/{{ release.previous.version }}..HEAD
+    {% endif -%}
+{% endfor %}
+"""
+# remove the leading and trailing whitespace from the templates
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = false
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^[a|A]dd", group = "Added" },
+    { message = "^[s|S]upport", group = "Added" },
+    { message = "^[r|R]emove", group = "Removed" },
+    { message = "^.*: add", group = "Added" },
+    { message = "^.*: support", group = "Added" },
+    { message = "^.*: remove", group = "Removed" },
+    { message = "^.*: delete", group = "Removed" },
+    { message = "^test", group = "Fixed" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^.*: fix", group = "Fixed" },
+    { message = "^.*", group = "Changed" },
+]
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,49 @@
+[workspace]
+# path of the git-cliff configuration
+changelog_config = "cliff.toml"
+
+# enable changelog updates
+changelog_update = true
+
+# update dependencies with `cargo update`
+dependencies_update = true
+
+# Enable git releases for all packages by default
+git_release_enable = true
+
+# Enable git tags for all packages by default
+git_tag_enable = true
+
+# creates the git release as draft
+git_release_draft = true
+
+# If true, creates the release PR as a draft.
+pr_draft = true
+
+# labels for the release PR
+pr_labels = ["release"]
+
+# disallow updating repositories with uncommitted changes
+allow_dirty = false
+
+# disallow packaging with uncommitted changes
+publish_allow_dirty = false
+
+[[package]] # the double square brackets define a TOML table array
+name = "evm_rpc_canister"
+semver_check = false # disable API breaking changes checks
+publish = false # disable `cargo publish`
+
+[[package]] # the double square brackets define a TOML table array
+name = "evm_rpc_client"
+#git_release_enable = false # enable GitHub releases
+publish = true # enable `cargo publish`
+
+[[package]] # the double square brackets define a TOML table array
+name = "evm_rpc_types"
+#git_release_enable = false # enable GitHub releases
+publish = true # enable `cargo publish`
+
+[[package]]
+name = "e2e"
+release = false # don't process this package

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -30,7 +30,7 @@ allow_dirty = false
 publish_allow_dirty = false
 
 [[package]] # the double square brackets define a TOML table array
-name = "evm_rpc_canister"
+name = "evm_rpc"
 semver_check = false # disable API breaking changes checks
 publish = false # disable `cargo publish`
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,12 @@
+- SHA-256 hash: ${EVM_RPC_CANISTER_WASM_GZ_SHA256}
+
+## Deployments
+
+| Type                | Canister ID                                                                                                  | Deployed? |
+|---------------------|--------------------------------------------------------------------------------------------------------------|-----------|
+| :rocket: Production | [`7hfb6-caaaa-aaaar-qadga-cai`](https://dashboard.internetcomputer.org/canister/7hfb6-caaaa-aaaar-qadga-cai) | :x:       |
+| :test_tube: Staging | [`xhcuo-6yaaa-aaaar-qacqq-cai`](https://dashboard.internetcomputer.org/canister/xhcuo-6yaaa-aaaar-qacqq-cai) | :x:       |
+
+## What's Changed
+
+${CHANGELOG}


### PR DESCRIPTION
Add release and publish GitHub pipelines with `release-plz` to automate the creation of new releases.