### PR TITLE
fix: add `err_max_response_size_exceeded` to Prometheus metrics

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -104,6 +104,11 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
             &m.err_http_outcall,
             "Number of unsuccessful HTTP outcalls",
         );
+        w.counter_entries(
+            "evmrpc_err_max_response_size_exceeded",
+            &m.err_max_response_size_exceeded,
+            "Number of HTTP outcalls with max response size exceeded",
+        );
 
         Ok(())
     })

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2224,7 +2224,8 @@ async fn should_have_different_request_ids_when_retrying_because_response_too_bi
         .check_metrics()
         .await
         .assert_contains_metric_matching(r#"evmrpc_requests\{method="eth_getTransactionCount",host="cloudflare-eth.com"\} 2 \d+"#)
-        .assert_contains_metric_matching(r#"evmrpc_responses\{method="eth_getTransactionCount",host="cloudflare-eth.com",status="200"\} 1 \d+"#);
+        .assert_contains_metric_matching(r#"evmrpc_responses\{method="eth_getTransactionCount",host="cloudflare-eth.com",status="200"\} 1 \d+"#)
+        .assert_contains_metric_matching(r#"evmrpc_err_max_response_size_exceeded\{method="eth_getTransactionCount",host="cloudflare-eth.com"\} 1 \d+"#);
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR fixes a bug where `Metrics::err_max_response_size_exceeded` was not encoded in the Prometheus metrics.