### PR TITLE
refactor: remove remaining `ic-canister-log` usages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,7 +1558,6 @@ dependencies = [
  "getrandom 0.2.16",
  "hex",
  "http",
- "ic-canister-log",
  "ic-cdk",
  "ic-cdk-macros",
  "ic-crypto-test-utils-reproducible-rng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ ic-ethereum-types = { workspace = true }
 ic-http-types = { workspace = true }
 ic-metrics-encoder = { workspace = true }
 ic-stable-structures = { workspace = true }
-ic-canister-log = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-management-canister-types = { workspace = true }
@@ -85,7 +84,6 @@ ethnum = { version = "1.5.0", features = ["serde"] }
 getrandom = { version = "0.2", features = ["custom"] }
 hex = "0.4.3"
 http = "1.3.1"
-ic-canister-log = "0.2.0"
 ic-cdk = "0.17.2"
 ic-cdk-bindgen = "0.1"
 ic-cdk-macros = "0.17.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use canhttp::{multi::Timestamp, CyclesChargingPolicy, CyclesCostEstimator};
-use canlog::{Log, Sort};
+use canlog::{log, Log, Sort};
 use evm_rpc::{
     candid_rpc::CandidRpcClient,
     http::{
         json_rpc_request, json_rpc_request_arg, service_request_builder, transform_http_request,
         ChargingPolicyWithCollateral,
     },
-    logs::{Priority, INFO},
+    logs::Priority,
     memory::{
         get_num_subnet_nodes, insert_api_key, is_api_key_principal, is_demo_active, remove_api_key,
         set_api_key_principals, set_demo_active, set_log_filter, set_num_subnet_nodes,
@@ -17,7 +17,6 @@ use evm_rpc::{
     types::{OverrideProvider, Provider, ProviderId, RpcAccess, RpcAuth},
 };
 use evm_rpc_types::{Hex32, HttpOutcallError, MultiRpcResult, RpcConfig, RpcResult, RpcServices};
-use ic_canister_log::log;
 use ic_cdk::{
     api::{
         is_controller,
@@ -263,7 +262,7 @@ fn get_nodes_in_subnet() -> u32 {
 /// Panics if the list of provider IDs includes a nonexistent or "unauthenticated" (fully public) provider.
 async fn update_api_keys(api_keys: Vec<(ProviderId, Option<String>)>) {
     log!(
-        INFO,
+        Priority::Info,
         "[{}] Updating API keys for providers: {}",
         ic_cdk::caller(),
         api_keys

--- a/src/rpc_client/eth_rpc_error/mod.rs
+++ b/src/rpc_client/eth_rpc_error/mod.rs
@@ -1,8 +1,9 @@
-use crate::logs::DEBUG;
-use crate::rpc_client::json::responses::SendRawTransactionResult;
-use crate::rpc_client::json::Hash;
+use crate::{
+    logs::Priority,
+    rpc_client::json::{responses::SendRawTransactionResult, Hash},
+};
 use canhttp::http::json::{JsonRpcError, JsonRpcResponse};
-use ic_canister_log::log;
+use canlog::log;
 
 #[cfg(test)]
 mod tests;
@@ -184,7 +185,7 @@ pub fn sanitize_send_raw_transaction_result<T: ErrorParser>(body_bytes: &mut Vec
     let response: JsonRpcResponse<Hash> = match serde_json::from_slice(body_bytes) {
         Ok(response) => response,
         Err(e) => {
-            log!(DEBUG, "Error deserializing: {:?}", e);
+            log!(Priority::Debug, "Error deserializing: {:?}", e);
             return;
         }
     };


### PR DESCRIPTION
Remove the last remaining direct usages of `ic-canister-log::log` and replace them with `canlog::log`. As a result, the direct dependency on `ic-canister-log` is removed.