### PR TITLE
fix: `CHANGELOG` path in publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
           echo "release_version: $release_version"
           echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
           
-          notes=$(parse-changelog canister/CHANGELOG.md "$release_version")
+          notes=$(parse-changelog CHANGELOG.md "$release_version")
           
           CHANGELOG="$notes" envsubst < release_notes.md >> ${{ github.workspace }}-RELEASE.txt
 


### PR DESCRIPTION
Fix the path to the `CHANGELOG.md` file in the publish pipeline configuration.