### PR TITLE
chore: proposal to upgrade to v2.6.0

### DIFF
--- a/mainnet/proposals/evm_rpc_2025_10_24.md
+++ b/mainnet/proposals/evm_rpc_2025_10_24.md
@@ -15,8 +15,16 @@ Previous EVM RPC proposal: https://dashboard.internetcomputer.org/proposal/13847
 ---
 
 ## Motivation
-TODO: THIS MUST BE FILLED OUT
 
+Upgrade the EVM RPC canister to the latest version [v2.6.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.6.0),
+which includes in particular the following changes:
+* Add new `json_request` endpoint and deprecate existing `request` endpoint
+* Add support for `root` and `cumulativeGasUsed` fields in `eth_getTransactionReceipt` response
+* Remove `getMetrics` debugging endpoint
+* Update `ic-cdk` to v0.18.7 and cleanup unused dependencies
+* Add `err_max_response_size_exceeded` to Prometheus metrics
+
+See the Gihub release [v2.6.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.6.0) for more details.
 
 ## Release Notes
 


### PR DESCRIPTION
Proposal to upgrade the EVM RPC canister [7hfb6-caaaa-aaaar-qadga-cai](https://dashboard.internetcomputer.org/canister/7hfb6-caaaa-aaaar-qadga-cai) to [v2.6.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.6.0).