### PR TITLE
docs: expand `evm_rpc_client` README

### DIFF
--- a/evm_rpc_client/README.md
+++ b/evm_rpc_client/README.md
@@ -4,6 +4,29 @@
 
 # Crate `evm_rpc_client`
 
-Library to interact with the [EVM RPC canister](https://github.com/dfinity/evm-rpc-canister/) from a canister running on
-the Internet Computer.
+Library to interact with the [EVM RPC canister](https://github.com/dfinity/evm-rpc-canister/) from a canister running on the Internet Computer. 
+The `alloy` feature flag allows using [Alloy](https://alloy.rs/) types in requests and responses.
+
 See the Rust [documentation](https://docs.rs/evm_rpc_client) for more details.
+
+## Example
+Fetching the latest transaction count for a given address using the `eth_getTransactionCount` JSON-RPC method.
+
+```rust
+use alloy_primitives::{Adress, U256};
+use alloy_rpc_types::BlockNumberOrTag;
+use evm_rpc_client::EvmRpcClient;
+use evm_rpc_types::RpcResult;
+
+fn get_latest_transaction_count (address: Address) -> RpcResult<U256> {
+    let client = EvmRpcClient::builder_for_ic()
+        .with_alloy()
+        .build();
+
+    client
+        .get_transaction_count((address, BlockNumberOrTag::Latest))
+        .send()
+        .await
+        .expect_consistent()
+}
+```


### PR DESCRIPTION
Add more details to the `evm_rpc_client` README, including a link to the Rust doc.