### PR TITLE
docs: hide imports in Rust doc

### DIFF
--- a/evm_rpc_client/src/lib.rs
+++ b/evm_rpc_client/src/lib.rs
@@ -46,9 +46,8 @@
 //! use alloy_primitives::{address, U256};
 //! use alloy_rpc_types::BlockNumberOrTag;
 //! use evm_rpc_client::EvmRpcClient;
-//! use evm_rpc_types::MultiRpcResult;
 //!
-//! # use evm_rpc_types::Nat256;
+//! # use evm_rpc_types::{MultiRpcResult, Nat256};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = EvmRpcClient::builder_for_ic()
@@ -84,9 +83,9 @@
 //! use alloy_primitives::{address, U256};
 //! use alloy_rpc_types::BlockNumberOrTag;
 //! use evm_rpc_client::EvmRpcClient;
-//! use evm_rpc_types::{ConsensusStrategy, MultiRpcResult, RpcServices};
+//! use evm_rpc_types::{ConsensusStrategy, RpcServices};
 //!
-//! # use evm_rpc_types::Nat256;
+//! # use evm_rpc_types::{MultiRpcResult, Nat256};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = EvmRpcClient::builder_for_ic()


### PR DESCRIPTION
Hide `evm_rpc_types::MultiRpcResults` import statements in documentation where `MultiRpcResults` is only used in setup.