### PR TITLE
docs: use `sol!` macro in `eth_call` example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,7 +1977,6 @@ name = "evm_rpc_client"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-dyn-abi",
  "alloy-primitives",
  "alloy-rpc-types",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ tokio = { workspace = true }
 [workspace.dependencies]
 alloy = "1.0.42"
 alloy-consensus = "1.0.26"
-alloy-dyn-abi = "1.3.1"
 alloy-primitives = "1.3.0"
 alloy-rpc-types = "1.0.23"
 assert_matches = "1.5.0"

--- a/evm_rpc_client/Cargo.toml
+++ b/evm_rpc_client/Cargo.toml
@@ -25,7 +25,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 alloy = { workspace = true }
-alloy-dyn-abi = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-rpc-types = { workspace = true }
 evm_rpc_types = { path = "../evm_rpc_types", features = ["alloy"] }

--- a/evm_rpc_client/src/lib.rs
+++ b/evm_rpc_client/src/lib.rs
@@ -336,7 +336,6 @@ impl<R, C: EvmRpcResponseConverter, P> EvmRpcClient<R, C, P> {
     ///
     /// ```rust
     /// use alloy::{sol, sol_types::{SolCall, SolInterface}};
-    /// use alloy_dyn_abi::{DynSolType, DynSolValue};
     /// use alloy_primitives::{address, bytes, Bytes};
     /// use alloy_rpc_types::BlockNumberOrTag;
     /// use evm_rpc_client::EvmRpcClient;


### PR DESCRIPTION
Adapt the example in the documentation for the `EvmRpcClient::eth_call` method to use the `alloy::sol` macro. This allows defining the Solidity interface of the contract being called instead of hardcoding the input bytes and provides an example of using the `sol` macro with the EVM RPC canister.