### PR TITLE
chore: proposal to upgrade to v2.7.0

### DIFF
--- a/mainnet/proposals/evm_rpc_2025_11_06.md
+++ b/mainnet/proposals/evm_rpc_2025_11_06.md
@@ -15,8 +15,13 @@ Previous EVM RPC proposal: https://dashboard.internetcomputer.org/proposal/13908
 ---
 
 ## Motivation
-TODO: THIS MUST BE FILLED OUT
 
+Upgrade the EVM RPC canister to the latest version [v2.7.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.7.0),
+which includes in particular the following changes:
+* For each `eth_*` endpoint, add a new corresponding `eth_*CyclesCost` query endpoint with the same Candid arguments, that allows computing the cycles cost of calling the corresponding `eth_*` update endpoint.
+* Use constant-size JSON-RPC request IDs for consistent request cost calculations.
+
+See the Gihub release [v2.7.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.7.0) for more details.
 
 ## Release Notes
 


### PR DESCRIPTION
Proposal to upgrade the EVM RPC canister [7hfb6-caaaa-aaaar-qadga-cai](https://dashboard.internetcomputer.org/canister/7hfb6-caaaa-aaaar-qadga-cai) to [v2.7.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.7.0).