### PR TITLE
feat: add supported `RpcService` metrics label

### DIFF
--- a/evm_rpc_client/src/request/mod.rs
+++ b/evm_rpc_client/src/request/mod.rs
@@ -507,6 +507,12 @@ impl<Runtime, Converter, RetryPolicy, Config, Params, CandidOutput, Output>
         }
     }
 
+    /// Change the [`RpcServices`] for that request.
+    pub fn with_rpc_sources(mut self, rpc_services: RpcServices) -> Self {
+        self.request.rpc_services = rpc_services;
+        self
+    }
+
     /// Change the amount of cycles to send for that request.
     pub fn with_cycles(mut self, cycles: u128) -> Self {
         *self.request.cycles_mut() = cycles;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use evm_rpc::{
         set_override_provider,
     },
     metrics::encode_metrics,
-    providers::{find_provider, resolve_rpc_service, PROVIDERS, SERVICE_PROVIDER_MAP},
+    providers::{find_provider, PROVIDERS, SERVICE_PROVIDER_MAP},
     types::{OverrideProvider, Provider, ProviderId, RpcAccess, RpcAuth},
 };
 use evm_rpc_types::{Hex32, HttpOutcallError, MultiRpcResult, RpcConfig, RpcResult, RpcServices};
@@ -259,12 +259,7 @@ async fn request(
     json_rpc_payload: String,
     max_response_bytes: u64,
 ) -> RpcResult<String> {
-    let response = json_rpc_request(
-        resolve_rpc_service(service)?,
-        &json_rpc_payload,
-        max_response_bytes,
-    )
-    .await?;
+    let response = json_rpc_request(service, &json_rpc_payload, max_response_bytes).await?;
     serde_json::to_string(response.body()).map_err(|e| {
         HttpOutcallError::InvalidHttpJsonRpcResponse {
             status: response.status().as_u16(),
@@ -284,11 +279,7 @@ async fn request_cost(
     if is_demo_active() {
         Ok(0)
     } else {
-        let request = json_rpc_request_arg(
-            resolve_rpc_service(service)?,
-            &json_rpc_payload,
-            max_response_bytes,
-        )?;
+        let request = json_rpc_request_arg(service, &json_rpc_payload, max_response_bytes)?;
 
         async fn extract_request(
             request: IcHttpRequest,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -119,17 +119,18 @@ impl MetricLabels for MetricRpcMethod {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, CandidType, Deserialize)]
-pub struct MetricRpcHost(pub String);
-
-impl From<&str> for MetricRpcHost {
-    fn from(hostname: &str) -> Self {
-        MetricRpcHost(hostname.to_string())
-    }
+pub struct MetricRpcService {
+    pub host: String,
+    pub is_supported: bool,
 }
 
-impl MetricLabels for MetricRpcHost {
+impl MetricLabels for MetricRpcService {
     fn metric_labels(&self) -> Vec<(&str, &str)> {
-        vec![("host", &self.0)]
+        let mut labels = vec![("host", self.host.as_str())];
+        if self.is_supported {
+            labels.push(("is_supported_provider", "true"));
+        }
+        labels
     }
 }
 
@@ -166,18 +167,18 @@ impl MetricLabels for LegacyRejectionCode {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, CandidType, Deserialize)]
 pub struct Metrics {
-    pub requests: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
-    pub responses: HashMap<(MetricRpcMethod, MetricRpcHost, MetricHttpStatusCode), u64>,
+    pub requests: HashMap<(MetricRpcMethod, MetricRpcService), u64>,
+    pub responses: HashMap<(MetricRpcMethod, MetricRpcService, MetricHttpStatusCode), u64>,
     #[serde(rename = "inconsistentResponses")]
-    pub inconsistent_responses: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
+    pub inconsistent_responses: HashMap<(MetricRpcMethod, MetricRpcService), u64>,
     #[serde(rename = "cyclesCharged")]
-    pub cycles_charged: HashMap<(MetricRpcMethod, MetricRpcHost), u128>,
+    pub cycles_charged: HashMap<(MetricRpcMethod, MetricRpcService), u128>,
     #[serde(rename = "errHttpOutcall")]
-    pub err_http_outcall: HashMap<(MetricRpcMethod, MetricRpcHost, LegacyRejectionCode), u64>,
+    pub err_http_outcall: HashMap<(MetricRpcMethod, MetricRpcService, LegacyRejectionCode), u64>,
     #[serde(rename = "errMaxResponseSizeExceeded")]
-    pub err_max_response_size_exceeded: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
+    pub err_max_response_size_exceeded: HashMap<(MetricRpcMethod, MetricRpcService), u64>,
     #[serde(rename = "errNoConsensus")]
-    pub err_no_consensus: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
+    pub err_no_consensus: HashMap<(MetricRpcMethod, MetricRpcService), u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
(DEFI-2461) Add Prometheus metrics label for requests with made with supported `RpcService`. 

The new label does not just check the host the request is made to, to avoid incorrectly labelling requests made to known RPC providers with custom API keys as "supported". Instead, the specific variant of `RpcServices` (or `RpcService` for the legacy `request` endpoint) is checked.