### PR TITLE
chore: proposal to upgrade to v2.7.1

### DIFF
--- a/mainnet/proposals/evm_rpc_2025_11_17.md
+++ b/mainnet/proposals/evm_rpc_2025_11_17.md
@@ -1,0 +1,51 @@
+# Proposal to upgrade the EVM RPC canister
+
+Repository: `https://github.com/dfinity/evm-rpc-canister.git`
+
+Git hash: `d8f47fcad59bc736247037350754db957ec43af4`
+
+New compressed Wasm hash: `f61b3c2970548b611fcc9285eca94aace166e3c295cb98287c9e009a1075d392`
+
+Upgrade args hash: `6005397a2ddf2ee644ceaca123c9afbd2360f0644e7e5e6c4ac320a5f7bd4a82`
+
+Target canister: `7hfb6-caaaa-aaaar-qadga-cai`
+
+Previous EVM RPC proposal: https://dashboard.internetcomputer.org/proposal/139311
+
+---
+
+## Motivation
+
+Upgrade the EVM RPC canister to the latest version [v2.7.1](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.7.1),
+which includes some changes in the way metrics are recorded.
+
+See the GitHub release [v2.7.1](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.7.1) for more details.
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' 32c067d3b19ccc91e3abd991f9c6c2204466021a..d8f47fcad59bc736247037350754db957ec43af4 --
+d8f47fc chore: release (#523)
+e5e320a feat: add supported `RpcService` metrics label (#521)
+0b91d67 chore: separate metrics for consensus errors (#520)
+c73c562 chore: proposal to upgrade to v2.7.0 (#519)
+ ```
+
+## Upgrade args
+
+```
+git fetch
+git checkout d8f47fcad59bc736247037350754db957ec43af4
+didc encode -d candid/evm_rpc.did -t '(InstallArgs)' '(record {})' | xxd -r -p | sha256sum
+```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout d8f47fcad59bc736247037350754db957ec43af4
+"./scripts/docker-build"
+sha256sum ./evm_rpc.wasm.gz
+```


### PR DESCRIPTION
Proposal to upgrade the EVM RPC canister [7hfb6-caaaa-aaaar-qadga-cai](https://dashboard.internetcomputer.org/canister/7hfb6-caaaa-aaaar-qadga-cai) to [v2.7.1](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.7.1).