### PR TITLE
chore: bump `pocket-ic` to v10.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Install PocketIC server
         uses: dfinity/pocketic@main
         with:
-          pocket-ic-server-version: "9.0.1"
+          pocket-ic-server-version: "10.0.0"
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "ic-metrics-assert"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a58acbcd7c46554a52b8340e4f326d57ebf5c2d9dc7722f30ccf3e67dcb1c9"
+checksum = "7d74f5e67d382d612d7b4f2d232ea0cf6a8e777c8e0099cd45e01cf68efae0aa"
 dependencies = [
  "async-trait",
  "candid",
@@ -3587,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "9.0.2"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e523c23bda9dc26ae989aab647b8bd805b54c72a3f2f00d668830d8b490c9c8"
+checksum = "4c9b78f339182efb981ceca2ac360aa280609f8d8c785e5a7eeda488f53497a8"
 dependencies = [
  "backoff",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,14 +93,14 @@ ic-http-types = "0.1.0"
 ic-error-types = "0.2"
 ic-ethereum-types = "1.0.0"
 ic-management-canister-types = "0.5.0"
-ic-metrics-assert = { version = "0.1.1", features = ["pocket_ic"] }
+ic-metrics-assert = { version = "0.2.0", features = ["pocket_ic"] }
 ic-metrics-encoder = "1.1"
 ic-stable-structures = "0.6.8"
 maplit = "1.0.2"
 minicbor = { version = "1.0.0", features = ["alloc", "derive"] }
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
-pocket-ic = "9.0.0"
+pocket-ic = "10.0.0"
 proptest = "1.6.0"
 rand = "0.8.0"
 regex = "1.11"

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -14,8 +14,7 @@ use evm_rpc::{
 use evm_rpc_client::{AlloyResponseConverter, ClientBuilder, EvmRpcClient, NoRetry, Runtime};
 use evm_rpc_types::{InstallArgs, Provider, RpcResult, RpcService};
 use ic_http_types::{HttpRequest, HttpResponse};
-use ic_management_canister_types_pocket_ic::CanisterId;
-use ic_management_canister_types_pocket_ic::CanisterSettings;
+use ic_management_canister_types_pocket_ic::{CanisterId, CanisterSettings};
 use ic_metrics_assert::{MetricsAssert, PocketIcAsyncHttpQuery};
 use ic_test_utilities_load_wasm::load_wasm;
 use num_traits::ToPrimitive;


### PR DESCRIPTION
Bump `pocket-ic` to v10.0.0 as well as `ic_metrics_assert` to v2.0.0 for compatibility with the new `pocket-ic` version.