### PR TITLE
fix: bump `evm_rpc` to v2.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "evm_rpc"
-version = "2.7.1"
+version = "2.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm_rpc"
-version = "2.7.1"
+version = "2.8.0"
 description = "Interact with EVM blockchains from the Internet Computer."
 authors = ["DFINITY Foundation"]
 readme = "README.md"


### PR DESCRIPTION
Bump `evm_rpc` to v2.8.0. This was accidentally left out of #530.