### PR TITLE
chore: proposal to upgrade to v2.8.0

### DIFF
--- a/mainnet/proposals/evm_rpc_2025_12_12.md
+++ b/mainnet/proposals/evm_rpc_2025_12_12.md
@@ -15,8 +15,11 @@ Previous EVM RPC proposal: https://dashboard.internetcomputer.org/proposal/13941
 ---
 
 ## Motivation
-TODO: THIS MUST BE FILLED OUT
 
+Upgrade the EVM RPC canister to the latest version [v2.8.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.8.0),
+which includes bumping the `ic-cdk` to v0.19.0 and Rust to v0.91.0.
+
+See the GitHub release [v2.8.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.8.0) for more details.
 
 ## Release Notes
 


### PR DESCRIPTION
Proposal to upgrade the EVM RPC canister [7hfb6-caaaa-aaaar-qadga-cai](https://dashboard.internetcomputer.org/canister/7hfb6-caaaa-aaaar-qadga-cai) to [v2.8.0](https://github.com/dfinity/evm-rpc-canister/releases/tag/evm_rpc-v2.8.0).