### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - run: rustup component add clippy
 
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - run: rustup component add clippy
 
@@ -62,14 +62,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
 
       - name: Docker build
         run: |
           ./scripts/docker-build
 
       - name: Archive Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: evm_rpc.wasm.gz
           path: evm_rpc.wasm.gz
@@ -85,15 +85,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: 'Download artifacts'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: evm_rpc.wasm.gz
 
       - name: 'Install `ic-wasm`'
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@80e6af7a2ec7f280fffe2d0a9d3a12a9d11d86e9 # v2.75.1
         with:
           tool: ic-wasm
 
@@ -106,10 +106,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: evm_rpc.wasm.gz
       
@@ -126,11 +126,11 @@ jobs:
           echo "WALLET_WASM_PATH=$GITHUB_WORKSPACE/wallet.wasm.gz" >> "$GITHUB_ENV"
  
       - name: Install PocketIC server
-        uses: dfinity/pocketic@main
+        uses: dfinity/pocketic@20c33db1aa87cc6ece50857ac632c37acf5e0322 # main
         with:
           pocket-ic-server-version: "12.0.0"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Cargo test
         run: cargo test --workspace --all-features -- --test-threads=2 --nocapture
@@ -139,12 +139,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install dfx
-        uses: dfinity/setup-dfx@main
+        uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
 
       - name: Start dfx
         run: dfx start --background
@@ -159,7 +159,7 @@ jobs:
         run: scripts/examples evm_rpc 'Number = 20000000'
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
 
       - name: Run anvil
         run: anvil &

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,13 +16,13 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: "Download build for Release Candidate"
         #     Adapted from [Internet Identity](https://github.com/dfinity/internet-identity/blob/c33e9f65a8045cbedde6f96cfb7f7cb677694fc9/.github/workflows/deploy-rc.yml#L22)
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             // Find all artifacts for the production build, and filter for non-expired main artifacts
@@ -65,7 +65,7 @@ jobs:
           echo "EVM_RPC_CANISTER_WASM_GZ_SHA256=$SHA256" >> "$GITHUB_ENV"
 
       - name: "Install parse-changelog"
-        uses: taiki-e/install-action@parse-changelog
+        uses: taiki-e/install-action@aae713f08c6f60f48c96bc317278d72757f5c408 # parse-changelog
 
       - name: "Run release-plz"
         id: release-plz
@@ -99,7 +99,7 @@ jobs:
           CHANGELOG="$notes" envsubst < release_notes.md >> ${{ github.workspace }}-RELEASE.txt
 
       - name: "Create Github release"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           draft: true
           tag_name: ${{ env.RELEASE_TAG}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Run release-plz


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@master` -> `actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master`
  - Version: master | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/61b9e3751b92087fd0b06925ba6dd6314e06f089

- `Swatinem/rust-cache@v2` -> `Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2`
  - Version: v2 | Latest: v2.9.1 | Release age: 27d
  - Commit: https://github.com/Swatinem/rust-cache/commit/e18b497796c12c097a38f9edb9d0641fb99eee32

- `actions/upload-artifact@v4` -> `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
  - Version: v4.6.2 | Latest: v3.2.2 | Release age: 22d
  - Commit: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/download-artifact@v4` -> `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0`
  - Version: v4.3.0 | Latest: v3.1.0-node20 | Release age: 22d
  - Commit: https://github.com/actions/download-artifact/commit/d3f86a106a0bac45b974a628896c90dbdf5c8093
  - Warnings: 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `taiki-e/install-action@v2` -> `taiki-e/install-action@80e6af7a2ec7f280fffe2d0a9d3a12a9d11d86e9 # v2.75.1`
  - Version: v2.75.1 | Latest: v2.75.1 | Release age: 7d
  - Commit: https://github.com/taiki-e/install-action/commit/80e6af7a2ec7f280fffe2d0a9d3a12a9d11d86e9
  - Warnings: Latest release v2.75.1 is only 1 day(s) old (< 7 days). Using previous safe release.

- `dfinity/pocketic@main` -> `dfinity/pocketic@20c33db1aa87cc6ece50857ac632c37acf5e0322 # main`
  - Version: main | Latest: 13.0.0 | Release age: 16d
  - Commit: https://github.com/dfinity/pocketic/commit/20c33db1aa87cc6ece50857ac632c37acf5e0322

- `dfinity/setup-dfx@main` -> `dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/setup-dfx/commit/e50c04f104ee4285ec010f10609483cf41e4d365

- `foundry-rs/foundry-toolchain@v1` -> `foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0`
  - Version: v1.7.0 | Latest: v1.7.0 | Release age: 77d
  - Commit: https://github.com/foundry-rs/foundry-toolchain/commit/8789b3e21e6c11b2697f5eb56eddae542f746c10

- `actions/github-script@v7` -> `actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0`
  - Version: v7.1.0 | Latest: v8 | Release age: 216d
  - Commit: https://github.com/actions/github-script/commit/f28e40c7f34bde8b3046d885e986cb6290c5673b

- `taiki-e/install-action@parse-changelog` -> `taiki-e/install-action@aae713f08c6f60f48c96bc317278d72757f5c408 # parse-changelog`
  - Version: parse-changelog | Latest: v2.75.1 | Release age: 7d
  - Commit: https://github.com/taiki-e/install-action/commit/aae713f08c6f60f48c96bc317278d72757f5c408
  - Warnings: Latest release v2.75.1 is only 1 day(s) old (< 7 days). Using previous safe release.

- `softprops/action-gh-release@v2` -> `softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1`
  - Version: v2.6.1 | Latest: v2.6.1 | Release age: 24d
  - Commit: https://github.com/softprops/action-gh-release/commit/153bb8e04406b158c6c84fc1615b65b24149a1fe


### Files modified

- `.github/workflows/ci.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/release.yml`

### Security warnings

- 1 security advisory(ies) found
- Action has 1 known advisory(ies)
- Latest release v2.75.1 is only 1 day(s) old (< 7 days). Using previous safe release.