### PR TITLE
ci: add checks-pass aggregator job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,15 +174,7 @@ jobs:
   checks-pass:
     # Always run this job!
     if: always()
-    needs:
-      [
-        lint,
-        cargo-doc,
-        reproducible-build,
-        check-canister-wasm-endpoints,
-        cargo-test,
-        e2e,
-      ]
+    needs: [lint, cargo-doc, reproducible-build, check-canister-wasm-endpoints, cargo-test, e2e]
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,3 +166,26 @@ jobs:
 
       - name: Run local examples with Foundry
         run: scripts/examples evm_rpc_local 'Number = 0'
+
+  # Single aggregator status check. Configure GitHub branch protection
+  # to require `checks-pass` so that any failing, cancelled, or skipped
+  # upstream job blocks the merge, without having to enumerate every
+  # individual job in the ruleset.
+  checks-pass:
+    # Always run this job!
+    if: always()
+    needs:
+      [
+        lint,
+        cargo-doc,
+        reproducible-build,
+        check-canister-wasm-endpoints,
+        cargo-test,
+        e2e,
+      ]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Add a single `checks-pass` aggregator status check that depends on every quality-gate job in `ci.yml` and fails if any upstream job is non-success (failure, cancelled, or skipped).

This lets GitHub branch protection / rulesets gate merges on a single context name (`checks-pass`) instead of enumerating every individual job. It also future-proofs the protection rule: adding or removing a CI job only needs an update to the `needs:` list here.

Mirrors the pattern already in use in `dfinity/dogecoin-canister` (`.github/workflows/workflow.yml`) and `dfinity/sol-rpc-canister` (after #322).

## Ordering

Should merge **after #579** (the alloy/rand/ic-mops fix that gets `main` back to green). CI on this PR is expected to be red until #579 lands, since `main` itself currently fails on `lint`/`cargo-doc`/`cargo-test`/`e2e`. The new aggregator simply codifies that "if any of those is red, the merge gate is closed."

## Follow-up (admin action, not in this PR)

After this merges to `main`, an admin should add a `required_status_checks` rule listing `checks-pass` as a required context. That closes the gap that has allowed Dependabot bumps (e.g. #565, #572-#575) to merge with red CI.