### PR TITLE
chore: add mise for unified tool versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,15 +92,12 @@ jobs:
         with:
           name: evm_rpc.wasm.gz
 
-      - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - name: Setup mise
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
         with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
-        with:
-          version: 10.9.0
+          # Disable cache to avoid issues with wasm32 target
+          # See https://github.com/jdx/mise-action/issues/215
+          cache: false
 
       - name: 'Install pnpm packages'
         run: |
@@ -153,15 +150,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - name: Setup mise
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
         with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
-        with:
-          version: 10.9.0
+          # Disable cache to avoid issues with wasm32 target
+          # See https://github.com/jdx/mise-action/issues/215
+          cache: false
 
       - name: Install pnpm packages
         run: |

--- a/README.md
+++ b/README.md
@@ -92,14 +92,20 @@ Run the following commands to set up a local development environment:
 git clone https://github.com/internet-computer-protocol/evm-rpc-canister
 cd evm-rpc-canister
 
+# One-time: enable mise shell activation so mise-managed tools and
+# `node_modules/.bin` are added to your PATH inside the project directory.
+# See https://mise.jdx.dev/getting-started.html for your shell.
+eval "$(mise activate bash)"
+
 # Install Node, pnpm, and Rust via mise (https://mise.jdx.dev):
 mise install
 
 # Install project dependencies (icp, ic-wasm, mops):
 pnpm install
 
-# mise automatically adds `node_modules/.bin` to your PATH when you're in
-# the project directory, so `icp`, `ic-wasm`, and `mops` are directly callable.
+# With mise shell activation enabled, `node_modules/.bin` is on your PATH
+# inside the project directory, so `icp`, `ic-wasm`, and `mops` are directly
+# callable. Without activation, prefix with `mise exec --`.
 
 # Deploy to the local network
 icp network start -d

--- a/README.md
+++ b/README.md
@@ -92,15 +92,14 @@ Run the following commands to set up a local development environment:
 git clone https://github.com/internet-computer-protocol/evm-rpc-canister
 cd evm-rpc-canister
 
-# This repo requires Node 24+ and uses pnpm. Either enable Corepack (bundled with Node):
-corepack enable && corepack prepare pnpm@10.9.0 --activate
-# ...or install pnpm directly:
-#   npm install -g pnpm@10.9.0
+# Install Node, pnpm, and Rust via mise (https://mise.jdx.dev):
+mise install
+
+# Install project dependencies (icp, ic-wasm, mops):
 pnpm install
 
-# `icp`, `ic-wasm`, and `mops` are installed as versioned devDependencies.
-# Put them on PATH, or prefix invocations with `pnpm exec`.
-export PATH="$PWD/node_modules/.bin:$PATH"
+# mise automatically adds `node_modules/.bin` to your PATH when you're in
+# the project directory, so `icp`, `ic-wasm`, and `mops` are directly callable.
 
 # Deploy to the local network
 icp network start -d

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,9 @@
 [tools]
 node = "24"
 pnpm = "10.9.0"
-rust = { version = "1.91.0", components = "rustfmt,clippy", targets = "wasm32-unknown-unknown" }
 
 [env]
 _.path = ["./node_modules/.bin"]
+
+[settings]
+idiomatic_version_file_enable_tools = ["rust"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,7 @@
+[tools]
+node = "24"
+pnpm = "10.9.0"
+rust = { version = "1.91.0", components = "rustfmt,clippy", targets = "wasm32-unknown-unknown" }
+
+[env]
+_.path = ["./node_modules/.bin"]


### PR DESCRIPTION
## Summary

Replace the separate `actions/setup-node` + `pnpm/action-setup` CI steps with a single `jdx/mise-action` step driven by a new `mise.toml` pinning Node 24, pnpm 10.9.0, and Rust 1.91.0. Local development uses the same versions via `mise install`, so contributors and CI no longer diverge.

Follows the pattern used in [`dfinity/internet-intelligence`](https://github.com/dfinity/internet-intelligence). Addresses [DEFI-2821](https://dfinity.atlassian.net/browse/DEFI-2821).

[DEFI-2821]: https://dfinity.atlassian.net/browse/DEFI-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ