### PR TITLE
feat: derive Hash for evm_rpc_types hex wrappers

### DIFF
--- a/evm_rpc_types/src/lib.rs
+++ b/evm_rpc_types/src/lib.rs
@@ -131,7 +131,7 @@ impl_from_unchecked!( Nat256, usize u8 u16 u32 u64 u128 );
 macro_rules! impl_hex_string {
     ($name: ident($data: ty)) => {
         #[doc = concat!("Ethereum hex-string (String representation is prefixed by 0x) wrapping a `", stringify!($data), "`. ")]
-        #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+        #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[serde(try_from = "String", into = "String")]
         pub struct $name($data);
 
@@ -243,7 +243,7 @@ impl Hex256 {
 /// such as `0x0` or `0x1` into a byte. By default,
 /// `FromHex::from_hex` will return `Err(FromHexError::OddLength)`
 /// when trying to decode such strings.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Byte([u8; 1]);
 
 impl Byte {

--- a/evm_rpc_types/src/tests.rs
+++ b/evm_rpc_types/src/tests.rs
@@ -6,7 +6,11 @@ use proptest::{
     prop_assert, prop_assert_eq, proptest,
 };
 use serde::{de::DeserializeOwned, Serialize};
-use std::{ops::RangeInclusive, str::FromStr};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::RangeInclusive,
+    str::FromStr,
+};
 
 mod nat256 {
     use super::*;
@@ -143,6 +147,32 @@ mod hex_string {
             let double_digit_hex_parsed: HexByte = double_digit_hex.parse().unwrap();
             assert_eq!(double_digit_hex_parsed, expected_value);
         }
+    }
+
+    #[test]
+    fn should_allow_hex_values_as_hash_keys() {
+        let address = Hex20::from_str("0xdAC17F958D2ee523a2206206994597C13D831ec7").unwrap();
+        let tx_hash =
+            Hex32::from_str("0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f")
+                .unwrap();
+        let byte = HexByte::from(0x2_u8);
+        let bytes = Hex::from(vec![0xde, 0xad, 0xbe, 0xef]);
+        let bloom = Hex256::from([0xab; 256]);
+
+        let mut balances = HashMap::new();
+        balances.insert(address.clone(), Nat256::from(1_u8));
+
+        assert_eq!(balances.get(&address), Some(&Nat256::from(1_u8)));
+
+        let tx_hashes = HashSet::from([tx_hash.clone()]);
+        let bytes_values = HashSet::from([bytes.clone()]);
+        let byte_values = HashSet::from([byte.clone()]);
+        let bloom_values = HashSet::from([bloom.clone()]);
+
+        assert!(tx_hashes.contains(&tx_hash));
+        assert!(bytes_values.contains(&bytes));
+        assert!(byte_values.contains(&byte));
+        assert!(bloom_values.contains(&bloom));
     }
 
     fn encode_decode_roundtrip<T>(value: &str) -> Result<(), TestCaseError>


### PR DESCRIPTION
Fixes #393.

What changed:
- Derived `Hash` for the `evm_rpc_types` hex wrappers generated by `impl_hex_string!`.
- Derived `Hash` for the internal `Byte` wrapper so `HexByte` is covered too.
- Added regression coverage for `Hex20` as a `HashMap` key and `HexByte`, `Hex32`, `Hex256`, and `Hex` in `HashSet`s.

Why:
These wrappers already compare by decoded bytes through `Eq`, so hashing the same inner values is consistent with their equality behavior. This lets callers use hash-based collections when they need them without changing Candid, serde, display, or parsing behavior.

Checked:
- `cargo test -p evm_rpc_types`
- `cargo test -p evm_rpc_types --all-features`