### PR TITLE
fix(deps): bump undici to 7.28.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1621,8 +1621,8 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -2872,7 +2872,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -3485,7 +3485,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
Bumps the transitive `undici` dependency from 7.25.0 to 7.28.0 to clear two open Dependabot alerts:

- **GHSA-vmh5-mc38-953g** (high) — TLS certificate validation bypass via dropped `requestTls` in the SOCKS5 `ProxyAgent`.
- **GHSA-pr7r-676h-xcf6** (medium) — cross-user information disclosure via a shared-cache whitespace bypass.

`undici` is pulled in only as a transitive dev dependency (via `jsdom`, itself a dependency of the `@icp-sdk` JS CLI tooling). It is not linked into the on-chain Rust/Motoko canister Wasm, so real exposure was negligible; this keeps the dev toolchain clean of the advisories.

The change is intentionally scoped to `undici` alone — only the three `undici` entries in `pnpm-lock.yaml` move, leaving the rest of the lockfile untouched. Verified with `pnpm install --frozen-lockfile`.