### PR TITLE
build: bump rust toolchain from 1.91.0 to 1.97.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Raise the pinned Rust toolchain to 1.97.1, matching the `ic` monorepo.

The main motivation is to clear the minimum-supported-rustc floor that currently blocks recent dependency bumps — most immediately #618 (alloy-consensus 2.2.0), whose `alloy-*` crates require rustc >= 1.94.1. Once this lands, #618 rebases green with no further changes.

`rust-toolchain.toml` is the single source of truth: CI, the reproducible build (Dockerfile) and `scripts/bootstrap` all read it, so this one-line change covers every job.

Verified locally against 1.97.1 on the #618 branch: `cargo fmt`, `cargo clippy` (default + `--tests --benches`, `-D warnings`) and `cargo doc --all-features` (`--deny warnings`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)