### PR TITLE
build(deps): override brace-expansion with 5.0.7 to resolve alert #70

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
       "@icp-sdk/icp-cli"
     ],
     "overrides": {
-      "decompress": "npm:@xhmikosr/decompress@11.1.3"
+      "decompress": "npm:@xhmikosr/decompress@11.1.3",
+      "brace-expansion": "5.0.7"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   decompress: npm:@xhmikosr/decompress@11.1.3
+  brace-expansion: 5.0.7
 
 importers:
 
@@ -652,8 +653,8 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2199,7 +2200,7 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2895,7 +2896,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minipass@7.1.3: {}
 


### PR DESCRIPTION
Resolves high-severity Dependabot alert [#70](https://github.com/dfinity/evm-rpc-canister/security/dependabot/70) (GHSA-3jxr-9vmj-r5cp / CVE-2026-13149): the dev-only transitive dependency `brace-expansion@5.0.6` is vulnerable to a DoS via exponential-time expansion of consecutive non-expanding `{}` groups.

`brace-expansion` is pulled in transitively via `minimatch`. A plain `pnpm update` does not move it off 5.0.6, so this adds a pnpm override pinning it to the patched `5.0.7`, matching the pattern used for alert #68. `minimatch`'s `^5.0.2` range accepts 5.0.7, so no consumer breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)