### PR TITLE
fix(deps): bump undici to 7.29.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1478,8 +1478,8 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -2628,7 +2628,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -3198,7 +3198,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
Bumps the transitive `undici` dev dependency from 7.28.0 to 7.29.0, clearing five open Dependabot alerts (#79–#83): one high (cross-user information disclosure and cache poisoning) and four medium (response desynchronization, whitespace-bypass disclosure, cookie attribute injection, CRLF injection).

`undici` reaches the tree only via `jsdom`, itself a dependency of `ic-mops`, and is not linked into the on-chain canister Wasm — so actual exposure was negligible. This keeps the development toolchain clear of the advisories.

7.29.0 satisfies the `^7.21.0` range `jsdom` already declares, so this needs no `pnpm.overrides` entry: the bump lives purely in the lockfile, matching the approach in #606, and the version stays free to float upward on future updates rather than being pinned.

Scoped deliberately to `undici` alone — only its three lockfile entries and integrity hash move, leaving the rest of the lockfile untouched. Verified with `pnpm install --frozen-lockfile`.

The open `tar` advisories are handled separately, since `ic-mops` pins `tar` to an exact version and genuinely requires an override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)