### PR TITLE
build(deps): override tar with 7.5.22 to resolve tar advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     ],
     "overrides": {
       "decompress": "npm:@xhmikosr/decompress@11.1.3",
-      "brace-expansion": "5.0.7"
+      "brace-expansion": "5.0.7",
+      "tar": "7.5.22"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   decompress: npm:@xhmikosr/decompress@11.1.3
   brace-expansion: 5.0.7
+  tar: 7.5.22
 
 importers:
 
@@ -1421,8 +1422,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -2550,7 +2551,7 @@ snapshots:
       smol-toml: 1.6.1
       stream-to-promise: 3.0.0
       string-width: 7.2.0
-      tar: 7.5.16
+      tar: 7.5.22
       terminal-size: 4.0.0
       vscode-languageserver-textdocument: 1.0.12
     transitivePeerDependencies:
@@ -3136,7 +3137,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.16:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
Pins the transitive `tar` dev dependency to 7.5.22 via `pnpm.overrides`, clearing five advisories — one critical (decompression/parse DoS), one high (infinite loop on a negative entry size), and three medium including alert #74.

An override is the only mechanism available here. `ic-mops` is the sole consumer and pins `tar` to an exact `7.5.16` rather than a version range, so a lockfile-only bump would be undone on the next resolution — unlike the `undici` bump in #635, which fits inside a range its consumer already declares. There is also no newer `ic-mops` release to upgrade to.

7.5.22 is used rather than the 7.5.19 that clears the critical advisory, because a further advisory is only patched in 7.5.21. All of these are patch-level moves within 7.5.x.

`tar` is dev-only tooling and is not linked into the on-chain canister Wasm, so actual exposure was limited. Since overriding an exact pin carries real compatibility risk, this was checked by clearing the mops cache and confirming a from-scratch `mops install` still downloads and extracts packages correctly under the newer `tar`; `pnpm install --frozen-lockfile` is also reproducible. The lockfile changes are scoped to `tar` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)