### PR TITLE
fix: return validation error for invalid custom RPC URLs instead of trapping

### DIFF
--- a/src/http/observability.rs
+++ b/src/http/observability.rs
@@ -172,11 +172,8 @@ fn from_request<I>(request: &HttpJsonRpcRequest<I>) -> MetricData {
         .extensions()
         .get::<RpcService>()
         .expect("`RpcService` request extension missing");
-    let host = request
-        .uri()
-        .host()
-        .expect("Could not extract host from request URI")
-        .to_string();
+    // Runs before cycles accounting, so panicking here would reject the whole call.
+    let host = request.uri().host().unwrap_or("(unknown)").to_string();
     let service = MetricRpcService {
         host,
         is_supported: !matches!(rpc_service, RpcService::Custom(_)),

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -26,7 +26,7 @@ use canhttp::{
 };
 use evm_rpc_types::{
     ConsensusStrategy, JsonRpcError, MultiRpcResult, ProviderError, RpcConfig, RpcError, RpcResult,
-    RpcService, RpcServices,
+    RpcService, RpcServices, ValidationError,
 };
 use http::{Request, Response};
 use ic_management_canister_types::{
@@ -550,7 +550,7 @@ impl<Params, Output> MultiRpcRequest<Params, Output> {
             let request = resolve_rpc_service(provider.clone())
                 .map_err(RpcError::from)
                 .and_then(|rpc_service| rpc_service.post(&get_override_provider()))
-                .map(|builder| {
+                .and_then(|builder| {
                     builder
                         .max_response_bytes(effective_size_estimate)
                         .transform_context(TransformContext {
@@ -564,7 +564,11 @@ impl<Params, Output> MultiRpcRequest<Params, Output> {
                             self.method.clone().name(),
                             self.params.clone(),
                         ))
-                        .expect("BUG: invalid request")
+                        .map_err(|e| {
+                            RpcError::ValidationError(ValidationError::Custom(format!(
+                                "Invalid request: {e}"
+                            )))
+                        })
                 })
                 .map(|mut request| {
                     // Store the original `RpcService` for usage when recording metrics

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -46,10 +46,10 @@ impl ResolvedRpcService {
         let url = api
             .url
             .parse::<http::Uri>()
-            .map_err(|e| format!("invalid URL: {e}"))
+            .map_err(|e| format!("Invalid URL: {e}"))
             .and_then(|url| match url.host() {
                 Some(_) => Ok(url),
-                None => Err("invalid URL: missing host".to_string()),
+                None => Err("Invalid URL: missing host".to_string()),
             })
             .map_err(|e| RpcError::ValidationError(ValidationError::Custom(e)))?;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -42,7 +42,18 @@ impl ResolvedRpcService {
         override_provider: &OverrideProvider,
     ) -> Result<http::request::Builder, RpcError> {
         let api = self.api(override_provider)?;
-        let mut request_builder = http::Request::post(api.url);
+        // The URL is never part of the error, since it can contain an API key.
+        let url = api
+            .url
+            .parse::<http::Uri>()
+            .map_err(|e| format!("invalid URL: {e}"))
+            .and_then(|url| match url.host() {
+                Some(_) => Ok(url),
+                None => Err("invalid URL: missing host".to_string()),
+            })
+            .map_err(|e| RpcError::ValidationError(ValidationError::Custom(e)))?;
+
+        let mut request_builder = http::Request::post(url);
         for HttpHeader { name, value } in api.headers.unwrap_or_default() {
             request_builder = request_builder.header(name, value);
         }

--- a/src/types/tests.rs
+++ b/src/types/tests.rs
@@ -220,3 +220,67 @@ mod override_provider {
         }
     }
 }
+
+mod resolved_rpc_service_post {
+    use crate::types::{OverrideProvider, ResolvedRpcService};
+    use assert_matches::assert_matches;
+    use evm_rpc_types::{RpcApi, RpcError, ValidationError};
+    use ic_management_canister_types::HttpHeader;
+
+    fn post(url: &str, headers: Option<Vec<HttpHeader>>) -> Result<http::Request<()>, RpcError> {
+        ResolvedRpcService::Api(RpcApi {
+            url: url.to_string(),
+            headers,
+        })
+        .post(&OverrideProvider::default())
+        .and_then(|builder| {
+            builder.body(()).map_err(|e| {
+                RpcError::ValidationError(ValidationError::Custom(format!("Invalid request: {e}")))
+            })
+        })
+    }
+
+    #[test]
+    fn should_accept_valid_url() {
+        let request = post("https://cloudflare-eth.com/v1/mainnet", None).unwrap();
+        assert_eq!(request.uri().host(), Some("cloudflare-eth.com"));
+    }
+
+    #[test]
+    fn should_return_validation_error_for_invalid_url() {
+        // These used to panic while building the request or while reading the host.
+        for url in [
+            "",                    // empty
+            "http://exa mple.com", // invalid URI character
+            "/foo",                // parses, but has no host
+        ] {
+            assert_matches!(
+                post(url, None),
+                Err(RpcError::ValidationError(ValidationError::Custom(_))),
+                "expected a validation error for url {url:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_leave_schemeless_url_to_the_management_canister() {
+        // `foo` parses as an authority, so it has a host. The management canister rejects it
+        // anyway, since an outcall URL has to be HTTPS.
+        let request = post("foo", None).unwrap();
+        assert_eq!(request.uri().host(), Some("foo"));
+    }
+
+    #[test]
+    fn should_return_validation_error_for_invalid_header() {
+        assert_matches!(
+            post(
+                "https://cloudflare-eth.com",
+                Some(vec![HttpHeader {
+                    name: "invalid header".to_string(),
+                    value: "value".to_string(),
+                }]),
+            ),
+            Err(RpcError::ValidationError(ValidationError::Custom(_)))
+        );
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,8 +9,9 @@ use canhttp::http::json::{ConstantSizeId, Id};
 use evm_rpc_client::{DoubleCycles, EvmRpcEndpoint, NoRetry, RequestBuilder};
 use evm_rpc_types::{
     BlockTag, ConsensusStrategy, EthMainnetService, EthSepoliaService, GetLogsRpcConfig, Hex,
-    Hex32, HttpOutcallError, InstallArgs, JsonRpcError, LegacyRejectionCode, MultiRpcResult,
-    Nat256, ProviderError, RpcApi, RpcError, RpcResult, RpcService, RpcServices, ValidationError,
+    Hex32, HttpHeader, HttpOutcallError, InstallArgs, JsonRpcError, LegacyRejectionCode,
+    MultiRpcResult, Nat256, ProviderError, RpcApi, RpcError, RpcResult, RpcService, RpcServices,
+    ValidationError,
 };
 use ic_canister_runtime::CyclesWalletRuntime;
 use ic_error_types::RejectCode;
@@ -982,6 +983,49 @@ async fn candid_rpc_should_allow_unexpected_response_fields() {
             "0x5115c07eb1f20a9d6410db0916ed3df626cfdab161d3904f45c8c8b65c90d0be"
         ))
     );
+}
+
+#[tokio::test]
+async fn candid_rpc_should_return_validation_error_for_invalid_custom_rpc_api() {
+    let setup = EvmRpcSetup::new().await.mock_api_keys().await;
+
+    // `RpcApi` is caller-controlled and used to make the canister trap.
+    for (url, headers) in [
+        ("", None),
+        ("http://exa mple.com", None),
+        ("/foo", None),
+        (
+            "https://cloudflare-eth.com",
+            Some(vec![HttpHeader {
+                name: "invalid header".to_string(),
+                value: "value".to_string(),
+            }]),
+        ),
+    ] {
+        let result = setup
+            .client(MockHttpOutcalls::never())
+            .with_rpc_sources(RpcServices::Custom {
+                chain_id: 1,
+                services: vec![RpcApi {
+                    url: url.to_string(),
+                    headers,
+                }],
+            })
+            .build()
+            .get_transaction_count((
+                address!("0xdac17f958d2ee523a2206206994597c13d831ec7"),
+                BlockNumberOrTag::Latest,
+            ))
+            .send()
+            .await
+            .expect_consistent();
+
+        assert_matches!(
+            result,
+            Err(RpcError::ValidationError(ValidationError::Custom(_))),
+            "expected a validation error for url {url:?}"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What's broken

Anyone can pass a custom RPC URL to this canister, but the URL was never checked. A bad one (empty string, a path with no host like `/foo`, or a URL with an invalid character) made the canister crash (trap) instead of returning a normal error.

## Fix

- Check the URL is valid before using it, and return a clean `ValidationError` if it isn't.
- Do the same for invalid headers.
- Reading the host for metrics no longer crashes if it's missing — fallsback to `"(unknown)"` instead.
- The bad URL itself is never included in the error message, since it can contain an API key.

## Testing

- Unit tests for empty URL, invalid character, missing host, bad header.
- An end-to-end test confirming the canister returns an error instead of crashing, and never makes an HTTP call for these inputs.
- `cargo test`, `cargo clippy`, `cargo fmt --check` all pass.