### PR TITLE
fix: reject duplicate RPC providers instead of silently deduplicating

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -19,8 +19,17 @@ pub fn arb_rpc_services() -> impl Strategy<Value = RpcServices> {
 pub fn arb_custom_rpc_services(
     num_providers: impl Into<SizeRange>,
 ) -> impl Strategy<Value = RpcServices> {
-    (any::<u64>(), vec(arb_rpc_api(), num_providers))
-        .prop_map(|(chain_id, services)| RpcServices::Custom { chain_id, services })
+    (any::<u64>(), vec(arb_rpc_api(), num_providers)).prop_map(|(chain_id, services)| {
+        let services = services
+            .into_iter()
+            .enumerate()
+            .map(|(i, mut api)| {
+                api.url = format!("{}#{i}", api.url);
+                api
+            })
+            .collect();
+        RpcServices::Custom { chain_id, services }
+    })
 }
 
 fn arb_rpc_api() -> impl Strategy<Value = RpcApi> {

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -5,7 +5,7 @@ use crate::{
         service_request_builder,
     },
     memory::{get_override_provider, rank_providers, record_ok_result},
-    providers::{resolve_rpc_service, SupportedRpcService},
+    providers::{self, resolve_rpc_service, SupportedRpcService},
     rpc_client::{
         eth_rpc::{
             ResponseSizeEstimate, ResponseTransform, ResponseTransformEnvelope, HEADER_SIZE_LIMIT,
@@ -162,6 +162,16 @@ fn choose_providers(
     strategy: ConsensusStrategy,
     now: Timestamp,
 ) -> Result<BTreeSet<RpcService>, ProviderError> {
+    if let Some(providers) = &user_input {
+        let unique: BTreeSet<RpcService> = providers.iter().cloned().collect();
+        if providers.len() != unique.len() {
+            return Err(ProviderError::InvalidRpcConfig(format!(
+                "duplicate providers are not allowed: {} services specified, but only {} are unique",
+                providers.len(),
+                unique.len()
+            )));
+        }
+    }
     match strategy {
         ConsensusStrategy::Equality => Ok(user_input
             .unwrap_or_else(|| {

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -5,7 +5,7 @@ use crate::{
         service_request_builder,
     },
     memory::{get_override_provider, rank_providers, record_ok_result},
-    providers::{self, resolve_rpc_service, SupportedRpcService},
+    providers::{resolve_rpc_service, SupportedRpcService},
     rpc_client::{
         eth_rpc::{
             ResponseSizeEstimate, ResponseTransform, ResponseTransformEnvelope, HEADER_SIZE_LIMIT,

--- a/src/rpc_client/mod.rs
+++ b/src/rpc_client/mod.rs
@@ -163,7 +163,7 @@ fn choose_providers(
     now: Timestamp,
 ) -> Result<BTreeSet<RpcService>, ProviderError> {
     if let Some(providers) = &user_input {
-        let unique: BTreeSet<RpcService> = providers.iter().cloned().collect();
+        let unique: BTreeSet<&RpcService> = providers.iter().collect();
         if providers.len() != unique.len() {
             return Err(ProviderError::InvalidRpcConfig(format!(
                 "duplicate providers are not allowed: {} services specified, but only {} are unique",

--- a/src/rpc_client/tests.rs
+++ b/src/rpc_client/tests.rs
@@ -243,7 +243,7 @@ mod providers {
     use canhttp::multi::Timestamp;
     use evm_rpc_types::{
         ConsensusStrategy, EthMainnetService, EthSepoliaService, L2MainnetService, ProviderError,
-        RpcServices,
+        RpcApi, RpcServices,
     };
     use proptest::arbitrary::any;
     use proptest::proptest;
@@ -294,6 +294,71 @@ mod providers {
                 Timestamp::default()
             ).unwrap();
         }
+    }
+
+    #[test]
+    fn should_reject_duplicate_custom_providers() {
+        let duplicate = RpcApi {
+            url: "https://eth-mainnet.g.alchemy.com/v2/some-key".to_string(),
+            headers: None,
+        };
+        let services = RpcServices::Custom {
+            chain_id: 1,
+            services: vec![duplicate.clone(), duplicate],
+        };
+
+        let providers = Providers::new(services, ConsensusStrategy::Equality, Timestamp::default());
+        assert_matches!(providers, Err(ProviderError::InvalidRpcConfig(_)));
+    }
+
+    #[test]
+    fn should_reject_duplicate_named_providers() {
+        let services = RpcServices::EthMainnet(Some(vec![
+            EthMainnetService::Alchemy,
+            EthMainnetService::Alchemy,
+        ]));
+
+        let providers = Providers::new(services, ConsensusStrategy::Equality, Timestamp::default());
+        assert_matches!(providers, Err(ProviderError::InvalidRpcConfig(_)));
+    }
+
+    #[test]
+    fn should_reject_duplicate_providers_under_threshold() {
+        let duplicate = RpcApi {
+            url: "https://eth-mainnet.g.alchemy.com/v2/some-key".to_string(),
+            headers: None,
+        };
+        let services = RpcServices::Custom {
+            chain_id: 1,
+            services: vec![duplicate.clone(), duplicate],
+        };
+        let strategy = ConsensusStrategy::Threshold {
+            total: Some(2),
+            min: 1,
+        };
+
+        let providers = Providers::new(services, strategy, Timestamp::default());
+        assert_matches!(providers, Err(ProviderError::InvalidRpcConfig(_)));
+    }
+
+    #[test]
+    fn should_accept_distinct_custom_providers_with_different_api_keys() {
+        let services = RpcServices::Custom {
+            chain_id: 1,
+            services: vec![
+                RpcApi {
+                    url: "https://eth-mainnet.g.alchemy.com/v2/key-a".to_string(),
+                    headers: None,
+                },
+                RpcApi {
+                    url: "https://eth-mainnet.g.alchemy.com/v2/key-b".to_string(),
+                    headers: None,
+                },
+            ],
+        };
+
+        let providers = Providers::new(services, ConsensusStrategy::Equality, Timestamp::default());
+        assert!(providers.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
- Canister lets you pick multiple RPC providers so it can check they all agree
- But if you pass the same provider twice, it gets stored in a data structure (a Set) that automatically removes duplicates
- So it silently becomes just 1 provider, with no warning
- It then still says "all providers agreed" even though only 1 was actually asked
- Example: pass [Alchemy, Alchemy, Alchemy] → canister only asks Alchemy once, but reports it as if 3 independent providers agreed
- This fix checks for duplicates before that happens, and rejects the request with a clear error instead
- Added tests for duplicate custom providers, duplicate named providers, and duplicate under threshold mode
- Also tested that different providers with different API keys still work fine (not treated as duplicates)